### PR TITLE
Passing to the code grant middleware callback areq instead of ares

### DIFF
--- a/lib/grant/code.js
+++ b/lib/grant/code.js
@@ -2,6 +2,7 @@
  * Module dependencies.
  */
 var url = require('url')
+  , utils = require('../utils')
   , AuthorizationError = require('../errors/authorizationerror');
 
 
@@ -152,7 +153,8 @@ module.exports = function code(options, issue) {
     
     var arity = issue.length;
     if (arity == 5) {
-      issue(txn.client, txn.req.redirectURI, txn.user, txn.req, issued);
+      var params = utils.merge(utils.merge({}, txn.req), txn.res);
+      issue(txn.client, txn.req.redirectURI, txn.user, params, issued);
     } else { // arity == 4
       issue(txn.client, txn.req.redirectURI, txn.user, issued);
     }


### PR DESCRIPTION
Code grant middleware doesn't pass scope to its callback function 
because it's stored in request. Instead, issue() function is passed
ares structure, which is no use when issuing authorization code.

Also, this fixes the broken documentation example:

``` javascript
server.grant(oauth2orize.grant.code(function(client, redirectURI, user, ares, done) {
    AuthorizationCode.create(client.id, redirectURI, user.id, ares.scope, function(err, code) {
        if (err) { return done(err); }
        done(null, code);
    });
}));
```
