### PR TITLE
Renamed "bearer" token to "Bearer"

### DIFF
--- a/lib/exchange/authorizationCode.js
+++ b/lib/exchange/authorizationCode.js
@@ -85,7 +85,7 @@ module.exports = function authorizationCode(options, issue) {
       tok['access_token'] = accessToken;
       if (refreshToken) { tok['refresh_token'] = refreshToken; }
       if (params) { utils.merge(tok, params); }
-      tok['token_type'] = tok['token_type'] || 'bearer';
+      tok['token_type'] = tok['token_type'] || 'Bearer';
       
       var json = JSON.stringify(tok);
       res.setHeader('Content-Type', 'application/json');

--- a/lib/exchange/clientCredentials.js
+++ b/lib/exchange/clientCredentials.js
@@ -103,7 +103,7 @@ module.exports = function clientCredentials(options, issue) {
       tok['access_token'] = accessToken;
       if (refreshToken) { tok['refresh_token'] = refreshToken; }
       if (params) { utils.merge(tok, params); }
-      tok['token_type'] = tok['token_type'] || 'bearer';
+      tok['token_type'] = tok['token_type'] || 'Bearer';
       
       var json = JSON.stringify(tok);
       res.setHeader('Content-Type', 'application/json');

--- a/lib/exchange/password.js
+++ b/lib/exchange/password.js
@@ -110,7 +110,7 @@ module.exports = function password(options, issue) {
       tok['access_token'] = accessToken;
       if (refreshToken) { tok['refresh_token'] = refreshToken; }
       if (params) { utils.merge(tok, params); }
-      tok['token_type'] = tok['token_type'] || 'bearer';
+      tok['token_type'] = tok['token_type'] || 'Bearer';
       
       var json = JSON.stringify(tok);
       res.setHeader('Content-Type', 'application/json');

--- a/lib/exchange/refreshToken.js
+++ b/lib/exchange/refreshToken.js
@@ -105,7 +105,7 @@ module.exports = function refreshToken(options, issue) {
       tok['access_token'] = accessToken;
       if (refreshToken) { tok['refresh_token'] = refreshToken; }
       if (params) { utils.merge(tok, params); }
-      tok['token_type'] = tok['token_type'] || 'bearer';
+      tok['token_type'] = tok['token_type'] || 'Bearer';
       
       var json = JSON.stringify(tok);
       res.setHeader('Content-Type', 'application/json');

--- a/lib/grant/token.js
+++ b/lib/grant/token.js
@@ -138,7 +138,7 @@ module.exports = function token(options, issue) {
       var tok = {};
       tok['access_token'] = accessToken;
       if (params) { utils.merge(tok, params); }
-      tok['token_type'] = tok['token_type'] || 'bearer';
+      tok['token_type'] = tok['token_type'] || 'Bearer';
       if (txn.req && txn.req.state) { tok['state'] = txn.req.state; }
       
       var parsed = url.parse(txn.redirectURI);

--- a/test/exchange/authorizationCode-test.js
+++ b/test/exchange/authorizationCode-test.js
@@ -74,7 +74,7 @@ vows.describe('authorizationCode').addBatch({
         assert.equal(res._headers['Pragma'], 'no-cache');
       },
       'should send response' : function(err, req, res) {
-        assert.equal(res._data, '{"access_token":"s3cr1t","token_type":"bearer"}');
+        assert.equal(res._data, '{"access_token":"s3cr1t","token_type":"Bearer"}');
       },
     },
   },
@@ -119,7 +119,7 @@ vows.describe('authorizationCode').addBatch({
         assert.equal(res._headers['Pragma'], 'no-cache');
       },
       'should send response' : function(err, req, res) {
-        assert.equal(res._data, '{"access_token":"s3cr1t","refresh_token":"getANotehr","token_type":"bearer"}');
+        assert.equal(res._data, '{"access_token":"s3cr1t","refresh_token":"getANotehr","token_type":"Bearer"}');
       },
     },
   },
@@ -164,7 +164,7 @@ vows.describe('authorizationCode').addBatch({
         assert.equal(res._headers['Pragma'], 'no-cache');
       },
       'should send response' : function(err, req, res) {
-        assert.equal(res._data, '{"access_token":"s3cr1t","expires_in":3600,"token_type":"bearer"}');
+        assert.equal(res._data, '{"access_token":"s3cr1t","expires_in":3600,"token_type":"Bearer"}');
       },
     },
   },
@@ -254,7 +254,7 @@ vows.describe('authorizationCode').addBatch({
         assert.equal(res._headers['Pragma'], 'no-cache');
       },
       'should send response' : function(err, req, res) {
-        assert.equal(res._data, '{"access_token":"s3cr1t","token_type":"bearer"}');
+        assert.equal(res._data, '{"access_token":"s3cr1t","token_type":"Bearer"}');
       },
     },
   },

--- a/test/exchange/clientCredentials-test.js
+++ b/test/exchange/clientCredentials-test.js
@@ -74,7 +74,7 @@ vows.describe('clientCredentials').addBatch({
         assert.equal(res._headers['Pragma'], 'no-cache');
       },
       'should send response' : function(err, req, res) {
-        assert.equal(res._data, '{"access_token":"s3cr1t","token_type":"bearer"}');
+        assert.equal(res._data, '{"access_token":"s3cr1t","token_type":"Bearer"}');
       },
     },
   },
@@ -119,7 +119,7 @@ vows.describe('clientCredentials').addBatch({
         assert.equal(res._headers['Pragma'], 'no-cache');
       },
       'should send response' : function(err, req, res) {
-        assert.equal(res._data, '{"access_token":"s3cr1t","refresh_token":"getANotehr","token_type":"bearer"}');
+        assert.equal(res._data, '{"access_token":"s3cr1t","refresh_token":"getANotehr","token_type":"Bearer"}');
       },
     },
   },
@@ -164,7 +164,7 @@ vows.describe('clientCredentials').addBatch({
         assert.equal(res._headers['Pragma'], 'no-cache');
       },
       'should send response' : function(err, req, res) {
-        assert.equal(res._data, '{"access_token":"s3cr1t","expires_in":3600,"token_type":"bearer"}');
+        assert.equal(res._data, '{"access_token":"s3cr1t","expires_in":3600,"token_type":"Bearer"}');
       },
     },
   },
@@ -255,7 +255,7 @@ vows.describe('clientCredentials').addBatch({
         assert.equal(res._headers['Pragma'], 'no-cache');
       },
       'should send response' : function(err, req, res) {
-        assert.equal(res._data, '{"access_token":"s3cr1t","token_type":"bearer"}');
+        assert.equal(res._data, '{"access_token":"s3cr1t","token_type":"Bearer"}');
       },
     },
   },
@@ -301,7 +301,7 @@ vows.describe('clientCredentials').addBatch({
         assert.equal(res._headers['Pragma'], 'no-cache');
       },
       'should send response' : function(err, req, res) {
-        assert.equal(res._data, '{"access_token":"s3cr1t","token_type":"bearer"}');
+        assert.equal(res._data, '{"access_token":"s3cr1t","token_type":"Bearer"}');
       },
     },
   },
@@ -347,7 +347,7 @@ vows.describe('clientCredentials').addBatch({
         assert.equal(res._headers['Pragma'], 'no-cache');
       },
       'should send response' : function(err, req, res) {
-        assert.equal(res._data, '{"access_token":"s3cr1t","token_type":"bearer"}');
+        assert.equal(res._data, '{"access_token":"s3cr1t","token_type":"Bearer"}');
       },
     },
   },
@@ -393,7 +393,7 @@ vows.describe('clientCredentials').addBatch({
         assert.equal(res._headers['Pragma'], 'no-cache');
       },
       'should send response' : function(err, req, res) {
-        assert.equal(res._data, '{"access_token":"s3cr1t","token_type":"bearer"}');
+        assert.equal(res._data, '{"access_token":"s3cr1t","token_type":"Bearer"}');
       },
     },
 
@@ -426,7 +426,7 @@ vows.describe('clientCredentials').addBatch({
         assert.equal(res._headers['Pragma'], 'no-cache');
       },
       'should send response' : function(err, req, res) {
-        assert.equal(res._data, '{"access_token":"s3cr1t","token_type":"bearer"}');
+        assert.equal(res._data, '{"access_token":"s3cr1t","token_type":"Bearer"}');
       },
     },
   },
@@ -471,7 +471,7 @@ vows.describe('clientCredentials').addBatch({
         assert.equal(res._headers['Pragma'], 'no-cache');
       },
       'should send response' : function(err, req, res) {
-        assert.equal(res._data, '{"access_token":"s3cr1t","token_type":"bearer"}');
+        assert.equal(res._data, '{"access_token":"s3cr1t","token_type":"Bearer"}');
       },
     },
   },

--- a/test/exchange/password-test.js
+++ b/test/exchange/password-test.js
@@ -74,7 +74,7 @@ vows.describe('password').addBatch({
         assert.equal(res._headers['Pragma'], 'no-cache');
       },
       'should send response' : function(err, req, res) {
-        assert.equal(res._data, '{"access_token":"s3cr1t","token_type":"bearer"}');
+        assert.equal(res._data, '{"access_token":"s3cr1t","token_type":"Bearer"}');
       },
     },
   },
@@ -119,7 +119,7 @@ vows.describe('password').addBatch({
         assert.equal(res._headers['Pragma'], 'no-cache');
       },
       'should send response' : function(err, req, res) {
-        assert.equal(res._data, '{"access_token":"s3cr1t","refresh_token":"getANotehr","token_type":"bearer"}');
+        assert.equal(res._data, '{"access_token":"s3cr1t","refresh_token":"getANotehr","token_type":"Bearer"}');
       },
     },
   },
@@ -164,7 +164,7 @@ vows.describe('password').addBatch({
         assert.equal(res._headers['Pragma'], 'no-cache');
       },
       'should send response' : function(err, req, res) {
-        assert.equal(res._data, '{"access_token":"s3cr1t","expires_in":3600,"token_type":"bearer"}');
+        assert.equal(res._data, '{"access_token":"s3cr1t","expires_in":3600,"token_type":"Bearer"}');
       },
     },
   },
@@ -255,7 +255,7 @@ vows.describe('password').addBatch({
         assert.equal(res._headers['Pragma'], 'no-cache');
       },
       'should send response' : function(err, req, res) {
-        assert.equal(res._data, '{"access_token":"s3cr1t","token_type":"bearer"}');
+        assert.equal(res._data, '{"access_token":"s3cr1t","token_type":"Bearer"}');
       },
     },
   },
@@ -301,7 +301,7 @@ vows.describe('password').addBatch({
         assert.equal(res._headers['Pragma'], 'no-cache');
       },
       'should send response' : function(err, req, res) {
-        assert.equal(res._data, '{"access_token":"s3cr1t","token_type":"bearer"}');
+        assert.equal(res._data, '{"access_token":"s3cr1t","token_type":"Bearer"}');
       },
     },
   },
@@ -347,7 +347,7 @@ vows.describe('password').addBatch({
         assert.equal(res._headers['Pragma'], 'no-cache');
       },
       'should send response' : function(err, req, res) {
-        assert.equal(res._data, '{"access_token":"s3cr1t","token_type":"bearer"}');
+        assert.equal(res._data, '{"access_token":"s3cr1t","token_type":"Bearer"}');
       },
     },
   },
@@ -393,7 +393,7 @@ vows.describe('password').addBatch({
         assert.equal(res._headers['Pragma'], 'no-cache');
       },
       'should send response' : function(err, req, res) {
-        assert.equal(res._data, '{"access_token":"s3cr1t","token_type":"bearer"}');
+        assert.equal(res._data, '{"access_token":"s3cr1t","token_type":"Bearer"}');
       },
     },
     
@@ -426,7 +426,7 @@ vows.describe('password').addBatch({
         assert.equal(res._headers['Pragma'], 'no-cache');
       },
       'should send response' : function(err, req, res) {
-        assert.equal(res._data, '{"access_token":"s3cr1t","token_type":"bearer"}');
+        assert.equal(res._data, '{"access_token":"s3cr1t","token_type":"Bearer"}');
       },
     },
   },
@@ -471,7 +471,7 @@ vows.describe('password').addBatch({
         assert.equal(res._headers['Pragma'], 'no-cache');
       },
       'should send response' : function(err, req, res) {
-        assert.equal(res._data, '{"access_token":"s3cr1t","token_type":"bearer"}');
+        assert.equal(res._data, '{"access_token":"s3cr1t","token_type":"Bearer"}');
       },
     },
   },

--- a/test/exchange/refreshToken-test.js
+++ b/test/exchange/refreshToken-test.js
@@ -74,7 +74,7 @@ vows.describe('refreshToken').addBatch({
         assert.equal(res._headers['Pragma'], 'no-cache');
       },
       'should send response' : function(err, req, res) {
-        assert.equal(res._data, '{"access_token":"s3cr1t","token_type":"bearer"}');
+        assert.equal(res._data, '{"access_token":"s3cr1t","token_type":"Bearer"}');
       },
     },
   },
@@ -119,7 +119,7 @@ vows.describe('refreshToken').addBatch({
         assert.equal(res._headers['Pragma'], 'no-cache');
       },
       'should send response' : function(err, req, res) {
-        assert.equal(res._data, '{"access_token":"s3cr1t","refresh_token":"getANotehr","token_type":"bearer"}');
+        assert.equal(res._data, '{"access_token":"s3cr1t","refresh_token":"getANotehr","token_type":"Bearer"}');
       },
     },
   },
@@ -164,7 +164,7 @@ vows.describe('refreshToken').addBatch({
         assert.equal(res._headers['Pragma'], 'no-cache');
       },
       'should send response' : function(err, req, res) {
-        assert.equal(res._data, '{"access_token":"s3cr1t","expires_in":3600,"token_type":"bearer"}');
+        assert.equal(res._data, '{"access_token":"s3cr1t","expires_in":3600,"token_type":"Bearer"}');
       },
     },
   },
@@ -255,7 +255,7 @@ vows.describe('refreshToken').addBatch({
         assert.equal(res._headers['Pragma'], 'no-cache');
       },
       'should send response' : function(err, req, res) {
-        assert.equal(res._data, '{"access_token":"s3cr1t","token_type":"bearer"}');
+        assert.equal(res._data, '{"access_token":"s3cr1t","token_type":"Bearer"}');
       },
     },
   },
@@ -301,7 +301,7 @@ vows.describe('refreshToken').addBatch({
         assert.equal(res._headers['Pragma'], 'no-cache');
       },
       'should send response' : function(err, req, res) {
-        assert.equal(res._data, '{"access_token":"s3cr1t","token_type":"bearer"}');
+        assert.equal(res._data, '{"access_token":"s3cr1t","token_type":"Bearer"}');
       },
     },
   },
@@ -347,7 +347,7 @@ vows.describe('refreshToken').addBatch({
         assert.equal(res._headers['Pragma'], 'no-cache');
       },
       'should send response' : function(err, req, res) {
-        assert.equal(res._data, '{"access_token":"s3cr1t","token_type":"bearer"}');
+        assert.equal(res._data, '{"access_token":"s3cr1t","token_type":"Bearer"}');
       },
     },
   },
@@ -393,7 +393,7 @@ vows.describe('refreshToken').addBatch({
         assert.equal(res._headers['Pragma'], 'no-cache');
       },
       'should send response' : function(err, req, res) {
-        assert.equal(res._data, '{"access_token":"s3cr1t","token_type":"bearer"}');
+        assert.equal(res._data, '{"access_token":"s3cr1t","token_type":"Bearer"}');
       },
     },
 
@@ -426,7 +426,7 @@ vows.describe('refreshToken').addBatch({
         assert.equal(res._headers['Pragma'], 'no-cache');
       },
       'should send response' : function(err, req, res) {
-        assert.equal(res._data, '{"access_token":"s3cr1t","token_type":"bearer"}');
+        assert.equal(res._data, '{"access_token":"s3cr1t","token_type":"Bearer"}');
       },
     },
   },
@@ -471,7 +471,7 @@ vows.describe('refreshToken').addBatch({
         assert.equal(res._headers['Pragma'], 'no-cache');
       },
       'should send response' : function(err, req, res) {
-        assert.equal(res._data, '{"access_token":"s3cr1t","token_type":"bearer"}');
+        assert.equal(res._data, '{"access_token":"s3cr1t","token_type":"Bearer"}');
       },
     },
   },

--- a/test/grant/token-test.js
+++ b/test/grant/token-test.js
@@ -345,7 +345,7 @@ vows.describe('code').addBatch({
         assert.isNull(err);
       },
       'should parse request' : function(err, req, res) {
-        assert.equal(res._redirect, 'http://example.com/auth/callback#access_token=xyz&token_type=bearer');
+        assert.equal(res._redirect, 'http://example.com/auth/callback#access_token=xyz&token_type=Bearer');
       },
     },
   },
@@ -392,7 +392,7 @@ vows.describe('code').addBatch({
         assert.isNull(err);
       },
       'should parse request' : function(err, req, res) {
-        assert.equal(res._redirect, 'http://example.com/auth/callback#access_token=xyz&token_type=bearer&state=f1o1o1');
+        assert.equal(res._redirect, 'http://example.com/auth/callback#access_token=xyz&token_type=Bearer&state=f1o1o1');
       },
     },
   },
@@ -438,7 +438,7 @@ vows.describe('code').addBatch({
         assert.isNull(err);
       },
       'should parse request' : function(err, req, res) {
-        assert.equal(res._redirect, 'http://example.com/auth/callback#access_token=xyz&token_type=bearer');
+        assert.equal(res._redirect, 'http://example.com/auth/callback#access_token=xyz&token_type=Bearer');
       },
     },
   },
@@ -480,7 +480,7 @@ vows.describe('code').addBatch({
         assert.isNull(err);
       },
       'should parse request' : function(err, req, res) {
-        assert.equal(res._redirect, 'http://example.com/auth/callback#access_token=xyz&expires_in=3600&token_type=bearer');
+        assert.equal(res._redirect, 'http://example.com/auth/callback#access_token=xyz&expires_in=3600&token_type=Bearer');
       },
     },
   },

--- a/test/middleware/token-test.js
+++ b/test/middleware/token-test.js
@@ -31,7 +31,7 @@ vows.describe('token').addBatch({
       var server = new Server();
       server.exchange('authorization_code', function(req, res, next) {
         if (req.body.code == 'abc123') {
-          var json = JSON.stringify({ token_type: 'bearer', access_token: 'aaa-111-ccc' });
+          var json = JSON.stringify({ token_type: 'Bearer', access_token: 'aaa-111-ccc' });
           res.end(json);
         } else {
           return done(new Error('something is wrong'));
@@ -64,7 +64,7 @@ vows.describe('token').addBatch({
         assert.isNull(err);
       },
       'should send response' : function(err, req, res) {
-        assert.equal(res._data, '{"token_type":"bearer","access_token":"aaa-111-ccc"}');
+        assert.equal(res._data, '{"token_type":"Bearer","access_token":"aaa-111-ccc"}');
       },
     },
   },
@@ -73,7 +73,7 @@ vows.describe('token').addBatch({
     topic: function() {
       var server = new Server();
       server.exchange('authorization_code', function(req, res, next) {
-        var json = JSON.stringify({ token_type: 'bearer', access_token: 'aaa-111-ccc' });
+        var json = JSON.stringify({ token_type: 'Bearer', access_token: 'aaa-111-ccc' });
         res.end(json);
       });
       


### PR DESCRIPTION
Renamed all instances where bearer token was named with a lowercase b to an uppercase B as per the OAuth 2.0 specs:
http://tools.ietf.org/html/draft-ietf-oauth-v2-bearer-20#section-4
