### PR TITLE
remove refresh token from client credentials grant

### DIFF
--- a/lib/exchange/clientCredentials.js
+++ b/lib/exchange/clientCredentials.js
@@ -22,11 +22,13 @@ var utils = require('../utils')
  * token.  `scope` is the scope of access requested by the client.  `done` is
  * called to issue an access token:
  *
- *     done(err, accessToken, refreshToken, params)
+ *     done(err, accessToken, [refreshToken], [params])
  *
  * `accessToken` is the access token that will be sent to the client.  An
  * optional `refreshToken` will be sent to the client, if the server chooses to
- * implement support for this functionality.  Any additional `params` will be
+ * implement support for this functionality.  Note that the spec states that
+ * you SHOULD NOT include a refresh token for client credentials grant.  Any
+ * additional `params` will be
  * included in the response.  If an error occurs, `done` should be invoked with
  * `err` set in idomatic Node.js fashion.
  *
@@ -98,7 +100,12 @@ module.exports = function clientCredentials(options, issue) {
     function issued(err, accessToken, refreshToken, params) {
       if (err) { return next(err); }
       if (!accessToken) { return next(new AuthorizationError('invalid client credentials', 'invalid_grant')); }
-      
+
+      if (typeof refreshToken == 'object') {
+        params = refreshToken;
+        refreshToken = null;
+      }
+
       var tok = {};
       tok['access_token'] = accessToken;
       if (refreshToken) { tok['refresh_token'] = refreshToken; }


### PR DESCRIPTION
RFC6749, Section 4.4.3 states the following:

```
A refresh token SHOULD NOT be included.
```

I think since the spec states that this should not be included, the user should explicit include it in the params if he wants it. Now it is like you should implement it.
