### PR TITLE
Implement immediate callback

### DIFF
--- a/lib/middleware/authorization.js
+++ b/lib/middleware/authorization.js
@@ -106,8 +106,10 @@ module.exports = function authorization(server, options, validate) {
   if (!server) throw new Error('OAuth 2.0 authorization middleware requires a server instance.');
   if (!validate) throw new Error('OAuth 2.0 authorization middleware requires a validate function.');
   
-  var lenTxnID = options.idLength || 8;
-  var key = options.sessionKey || 'authorize';
+  var lenTxnID = options.idLength || 8
+    , key = options.sessionKey || 'authorize'
+    , immediate = options.immediate || function (client, user, done) { done(); }
+    , userProperty = options.userProperty || 'user';
   
   return function authorization(req, res, next) {
     if (!req.session) { return next(new Error('OAuth 2.0 server requires session support.')); }
@@ -131,34 +133,45 @@ module.exports = function authorization(server, options, validate) {
         if (!client) { return next(new AuthorizationError('not authorized', 'unauthorized_client')); }
 
         req.oauth2.req = areq;
-        
-        // TODO: Add an optional `immediate` callback, which can consult a
-        //       pre-approved decision and respond immediately, along with the
-        //       ability to fall back into "transaction" mode.  Currently, this
-        //       functionality can be achieved using later route middleware
-        //       after `next()`ing, but this would optimize away the need to
-        //       serialize the client into the session.
+        req.oauth2.user = req[userProperty];
 
-        // A dialog needs to be conducted to obtain the user's approval.
-        // Serialize a transaction to the session.  The transaction will be
-        // restored (and removed) from the session when the user allows or
-        // denies the request.
-        server.serializeClient(client, function(err, obj) {
+        immediate(req.oauth2.client, req.oauth2.user, function (err, approved, params) {
           if (err) { return next(err); }
-          
-          var tid = utils.uid(lenTxnID);
-          req.oauth2.transactionID = tid;
-          
-          var txn = {};
-          txn.protocol = 'oauth2';
-          txn.client = obj;
-          txn.redirectURI = redirectURI;
-          txn.req = areq;
-          // store transaction in session
-          var txns = req.session[key] = req.session[key] || {};
-          txns[tid] = txn;
 
-          next();
+          if (approved) {
+            req.oauth2.res = { allow: true };
+            if (params) { utils.merge(req.oauth2.res, params); }
+
+            server._respond(req.oauth2, res, function(err) {
+              if (err) { return next(err); }
+              return next(new AuthorizationError('invalid response type', 'unsupported_response_type'));
+            });
+
+            return;
+          }
+
+
+          // A dialog needs to be conducted to obtain the user's approval.
+          // Serialize a transaction to the session.  The transaction will be
+          // restored (and removed) from the session when the user allows or
+          // denies the request.
+          server.serializeClient(client, function(err, obj) {
+            if (err) { return next(err); }
+
+            var tid = utils.uid(lenTxnID);
+            req.oauth2.transactionID = tid;
+
+            var txn = {};
+            txn.protocol = 'oauth2';
+            txn.client = obj;
+            txn.redirectURI = redirectURI;
+            txn.req = areq;
+            // store transaction in session
+            var txns = req.session[key] = req.session[key] || {};
+            txns[tid] = txn;
+
+            next();
+          });
         });
       }
       


### PR DESCRIPTION
I do not think the API I have chosen is the best. I'm thinking about these:

``` js
// 1)
// The one I have now.
server.authorization({ immediate: immediate }, findClient)

// 2)
server.authorization({}, immediate, findClient)

// 3)
server.authorization({}, findClient, immediate)

// 4)
server.immediate(immediate)

// 5)
// This breaks backward compatibility, but is the one I like most.
server.authorization(checkAuthorization)

// 6
server.authorization(function (clientID, redirectURI, scope, type, user, done) {
  checkAuthorization(
      { clientID: clientID
      , redirectURI: redirectURI
      , scope: scope
      , type: type
      }
    , user
    )
}

// 7
// Here we need to copy areq before we adds the user property.
server.authorization(function (areq, done) {
  checkAuthorization(areq, areq.user, done)
})



function checkAuthorization(areq, user, done) {
  findClient(areq.clientID, areq.redirectURI, function (err, client) {
    if (err) return done(err)

    immediate(client, areq.user, function (err, allow) {
      if (err) return done(err)

      return done(null, client, areq.redirectURI, { allow: allow })
    })
  })
})

function immediate(client, user, done) {
  db.authorizations.find(client, user, function (err, authorization) {
    done(err, !!authorization)
  })
}

function findClient(clientID, redirectURI, done) {
  db.clients.findByClientId(clientID, function (err, client) {
    if (err) return done(err)
    return done(null, client, redirectURI)
  })
}
```
