### PR TITLE
Pass req to callbacks

### DIFF
--- a/lib/exchange/authorizationCode.js
+++ b/lib/exchange/authorizationCode.js
@@ -77,27 +77,34 @@ module.exports = function(options, issue) {
       
     if (!code) { return next(new TokenError('Missing required parameter: code', 'invalid_request')); }
     
+    function issued(err, accessToken, refreshToken, params) {
+      if (err) { return next(err); }
+      if (!accessToken) { return next(new TokenError('Invalid authorization code', 'invalid_grant')); }
+      if (refreshToken && typeof refreshToken == 'object') {
+        params = refreshToken;
+        refreshToken = null;
+      }
+    
+      var tok = {};
+      tok.access_token = accessToken;
+      if (refreshToken) { tok.refresh_token = refreshToken; }
+      if (params) { utils.merge(tok, params); }
+      tok.token_type = tok.token_type || 'Bearer';
+    
+      var json = JSON.stringify(tok);
+      res.setHeader('Content-Type', 'application/json');
+      res.setHeader('Cache-Control', 'no-store');
+      res.setHeader('Pragma', 'no-cache');
+      res.end(json);
+    }
+
     try {
-      issue(client, code, redirectURI, function(err, accessToken, refreshToken, params) {
-        if (err) { return next(err); }
-        if (!accessToken) { return next(new TokenError('Invalid authorization code', 'invalid_grant')); }
-        if (refreshToken && typeof refreshToken == 'object') {
-          params = refreshToken;
-          refreshToken = null;
-        }
-      
-        var tok = {};
-        tok.access_token = accessToken;
-        if (refreshToken) { tok.refresh_token = refreshToken; }
-        if (params) { utils.merge(tok, params); }
-        tok.token_type = tok.token_type || 'Bearer';
-      
-        var json = JSON.stringify(tok);
-        res.setHeader('Content-Type', 'application/json');
-        res.setHeader('Cache-Control', 'no-store');
-        res.setHeader('Pragma', 'no-cache');
-        res.end(json);
-      });
+      var arity = issue.length;
+      if (arity == 5) {
+        issue(req, client, code, redirectURI, issued);
+      } else { // arity == 4
+        issue(client, code, redirectURI, issued);
+      }
     } catch (ex) {
       return next(ex);
     }

--- a/lib/exchange/clientCredentials.js
+++ b/lib/exchange/clientCredentials.js
@@ -121,6 +121,8 @@ module.exports = function(options, issue) {
       var arity = issue.length;
       if (arity == 3) {
         issue(client, scope, issued);
+      } else if (arity == 4) {
+        issue(req, client, scope, issued);
       } else { // arity == 2
         issue(client, issued);
       }

--- a/lib/exchange/password.js
+++ b/lib/exchange/password.js
@@ -127,6 +127,8 @@ module.exports = function(options, issue) {
       var arity = issue.length;
       if (arity == 5) {
         issue(client, username, passwd, scope, issued);
+      } else if (arity == 6) {
+        issue(req, client, username, passwd, scope, issued);
       } else { // arity == 4
         issue(client, username, passwd, issued);
       }

--- a/lib/exchange/refreshToken.js
+++ b/lib/exchange/refreshToken.js
@@ -122,6 +122,8 @@ module.exports = function(options, issue) {
       var arity = issue.length;
       if (arity == 4) {
         issue(client, refreshToken, scope, issued);
+      } else if (arity == 5) {
+        issue(req, client, refreshToken, scope, issued);
       } else { // arity == 3
         issue(client, refreshToken, issued);
       }

--- a/lib/grant/code.js
+++ b/lib/grant/code.js
@@ -117,7 +117,7 @@ module.exports = function code(options, issue) {
    * @param {Function} next
    * @api public
    */
-  function response(txn, res, next) {
+  function response(txn, req, res, next) {
     if (!txn.redirectURI) { return next(new Error('Unable to issue redirect for OAuth 2.0 transaction')); }
     if (!txn.res.allow) {
       var parsed = url.parse(txn.redirectURI, true);
@@ -154,6 +154,8 @@ module.exports = function code(options, issue) {
       var arity = issue.length;
       if (arity == 5) {
         issue(txn.client, txn.req.redirectURI, txn.user, txn.res, issued);
+      } else if (arity == 6) {
+        issue(req, txn.client, txn.req.redirectURI, txn.user, txn.res, issued);
       } else { // arity == 4
         issue(txn.client, txn.req.redirectURI, txn.user, issued);
       }

--- a/lib/grant/token.js
+++ b/lib/grant/token.js
@@ -117,7 +117,7 @@ module.exports = function token(options, issue) {
    * @param {Function} next
    * @api public
    */
-  function response(txn, res, next) {
+  function response(txn, req, res, next) {
     if (!txn.redirectURI) { return next(new Error('Unable to issue redirect for OAuth 2.0 transaction')); }
     if (!txn.res.allow) {
       var err = {};
@@ -159,6 +159,8 @@ module.exports = function token(options, issue) {
       var arity = issue.length;
       if (arity == 4) {
         issue(txn.client, txn.user, txn.res, issued);
+      } else if (arity == 5) {
+        issue(req, txn.client, txn.user, txn.res, issued);
       } else { // arity == 3
         issue(txn.client, txn.user, issued);
       }

--- a/lib/middleware/authorization.js
+++ b/lib/middleware/authorization.js
@@ -142,7 +142,7 @@ module.exports = function(server, options, validate, immediate) {
             req.oauth2.res = ares || {};
             req.oauth2.res.allow = true;
 
-            server._respond(req.oauth2, res, function(err) {
+            server._respond(req.oauth2, req, res, function(err) {
               if (err) { return next(err); }
               return next(new AuthorizationError('Unsupported response type: ' + req.oauth2.req.type, 'unsupported_response_type'));
             });
@@ -151,7 +151,7 @@ module.exports = function(server, options, validate, immediate) {
             // Serialize a transaction to the session.  The transaction will be
             // restored (and removed) from the session when the user allows or
             // denies the request.
-            server.serializeClient(client, function(err, obj) {
+            server.serializeClient(client, req, function(err, obj) {
               if (err) { return next(err); }
 
               var tid = utils.uid(lenTxnID);
@@ -187,6 +187,8 @@ module.exports = function(server, options, validate, immediate) {
           validate(areq.clientID, areq.redirectURI, areq.scope, validated);
         } else if (arity == 5) {
           validate(areq.clientID, areq.redirectURI, areq.scope, areq.type, validated);
+        } else if (arity == 6) {
+          validate(req, areq.clientID, areq.redirectURI, areq.scope, areq.type, validated);
         } else { // arity == 2
           validate(areq, validated);
         }

--- a/lib/middleware/decision.js
+++ b/lib/middleware/decision.js
@@ -105,7 +105,7 @@ module.exports = function(server, options, parse) {
         res.end(chunk, encoding);
       };
       
-      server._respond(req.oauth2, res, function(err) {
+      server._respond(req.oauth2, req, res, function(err) {
         if (err) { return next(err); }
         return next(new AuthorizationError('Unsupported response type: ' + req.oauth2.req.type, 'unsupported_response_type'));
       });

--- a/lib/middleware/transactionLoader.js
+++ b/lib/middleware/transactionLoader.js
@@ -44,7 +44,7 @@ module.exports = function(server, options) {
     var txn = req.session[key][tid];
     if (!txn) { return next(new ForbiddenError('Unable to load OAuth 2.0 transaction: ' + tid)); }
     
-    server.deserializeClient(txn.client, function(err, client) {
+    server.deserializeClient(txn.client, req, function(err, client) {
       if (err) { return next(err); }
       if (!client) {
         // At the time the request was initiated, the client was validated.

--- a/lib/server.js
+++ b/lib/server.js
@@ -167,7 +167,7 @@ Server.prototype.errorHandler = function(options) {
  *
  * @api public
  */
-Server.prototype.serializeClient = function(fn, done) {
+Server.prototype.serializeClient = function(fn, req, done) {
   if (typeof fn === 'function') {
     return this._serializers.push(fn);
   }
@@ -189,7 +189,16 @@ Server.prototype.serializeClient = function(fn, done) {
     }
     
     try {
-      layer(client, function(e, o) { pass(i + 1, e, o); } );
+      function serialized(e, o) {
+        pass(i + 1, e, o);
+      }
+
+      var arity = layer.length;
+      if (arity === 3) {
+        layer(req, client, serialized);
+      } else {
+        layer(client, serialized);
+      }
     } catch (ex) {
       return done(ex);
     }
@@ -209,7 +218,7 @@ Server.prototype.serializeClient = function(fn, done) {
  *
  * @api public
  */
-Server.prototype.deserializeClient = function(fn, done) {
+Server.prototype.deserializeClient = function(fn, req, done) {
   if (typeof fn === 'function') {
     return this._deserializers.push(fn);
   }
@@ -234,7 +243,16 @@ Server.prototype.deserializeClient = function(fn, done) {
     }
     
     try {
-      layer(obj, function(e, c) { pass(i + 1, e, c); } );
+      function deserialized(e, c) {
+        pass(i + 1, e, c);
+      }
+
+      var arity = layer.length;
+      if (arity === 3) {
+        layer(req, obj, deserialized);
+      } else {
+        layer(obj, deserialized);
+      }
     } catch (ex) {
       return done(ex);
     }
@@ -293,7 +311,7 @@ Server.prototype._parse = function(type, req, cb) {
  * @param {Function} cb
  * @api private
  */
-Server.prototype._respond = function(txn, res, cb) {
+Server.prototype._respond = function(txn, req, res, cb) {
   var ultype = new UnorderedList(txn.req.type)
     , stack = this._resHandlers
     , idx = 0;
@@ -307,7 +325,12 @@ Server.prototype._respond = function(txn, res, cb) {
     try {
       debug('respond:%s', layer.handle.name || 'anonymous');
       if (layer.type === null || layer.type.equalTo(ultype)) {
-        layer.handle(txn, res, next);
+        var arity = layer.handle.length;
+        if (arity === 4) {
+          layer.handle(txn, req, res, next);
+        } else {
+          layer.handle(txn, res, next);
+        }
       } else {
         next();
       }

--- a/test/server.response.test.js
+++ b/test/server.response.test.js
@@ -15,13 +15,14 @@ describe('Server', function() {
     
       before(function(done) {
         var txn = { req: { type: 'foo', scope: 'read' } };
+        var req = {};
         var res = {};
         res.end = function(data) {
           result = data;
           done();
         }
         
-        server._respond(txn, res, function(e) {
+        server._respond(txn, req, res, function(e) {
           done(new Error('should not be called'));
         });
       });
@@ -40,12 +41,13 @@ describe('Server', function() {
     
       before(function(done) {
         var txn = { req: { type: 'unsupported' } };
+        var req = {};
         var res = {};
         res.end = function(data) {
           done(new Error('should not be called'));
         }
         
-        server._respond(txn, res, function(e) {
+        server._respond(txn, req, res, function(e) {
           err = e;
           done();
         });
@@ -68,13 +70,14 @@ describe('Server', function() {
     
       before(function(done) {
         var txn = { req: { type: 'foo', scope: 'read' } };
+        var req = {};
         var res = {};
         res.end = function(data) {
           result = data;
           done();
         }
         
-        server._respond(txn, res, function(e) {
+        server._respond(txn, req, res, function(e) {
           done(new Error('should not be called'));
         });
       });
@@ -105,6 +108,7 @@ describe('Server', function() {
     
       before(function(done) {
         var txn = { req: { type: 'foo', scope: 'read' } };
+        var req = {};
         var res = {};
         res.end = function(data) {
           result = data;
@@ -112,7 +116,7 @@ describe('Server', function() {
         }
         
         response = res;
-        server._respond(txn, res, function(e) {
+        server._respond(txn, req, res, function(e) {
           done(new Error('should not be called'));
         });
       });
@@ -138,12 +142,13 @@ describe('Server', function() {
     
       before(function(done) {
         var txn = { req: { type: 'foo', scope: 'read' } };
+        var req = {};
         var res = {};
         res.end = function(data) {
           done(new Error('should not be called'));
         }
         
-        server._respond(txn, res, function(e) {
+        server._respond(txn, req, res, function(e) {
           err = e;
           done();
         });
@@ -167,12 +172,13 @@ describe('Server', function() {
     
       before(function(done) {
         var txn = { req: { type: 'foo', scope: 'read' } };
+        var req = {};
         var res = {};
         res.end = function(data) {
           done(new Error('should not be called'));
         }
         
-        server._respond(txn, res, function(e) {
+        server._respond(txn, req, res, function(e) {
           err = e;
           done();
         });
@@ -193,9 +199,10 @@ describe('Server', function() {
     
       before(function(done) {
         var txn = { req: { type: 'foo', scope: 'read' } };
+        var req = {};
         var res = {};
         
-        server._respond(txn, res, function(e) {
+        server._respond(txn, req, res, function(e) {
           err = e;
           done();
         });

--- a/test/server.serialization.test.js
+++ b/test/server.serialization.test.js
@@ -12,7 +12,7 @@ describe('Server', function() {
         var obj, err;
     
         before(function(done) {
-          server.serializeClient({ id: '1', name: 'Foo' }, function(e, o) {
+          server.serializeClient({ id: '1', name: 'Foo' }, {}, function(e, o) {
             err = e;
             obj = o;
             return done();
@@ -36,7 +36,7 @@ describe('Server', function() {
         var obj, err;
     
         before(function(done) {
-          server.serializeClient({ id: '1', name: 'Foo' }, function(e, o) {
+          server.serializeClient({ id: '1', name: 'Foo' }, {}, function(e, o) {
             err = e;
             obj = o;
             return done();
@@ -69,7 +69,7 @@ describe('Server', function() {
         var obj, err;
     
         before(function(done) {
-          server.serializeClient({ id: '1', name: 'Foo' }, function(e, o) {
+          server.serializeClient({ id: '1', name: 'Foo' }, {}, function(e, o) {
             err = e;
             obj = o;
             return done();
@@ -96,7 +96,7 @@ describe('Server', function() {
         var obj, err;
     
         before(function(done) {
-          server.serializeClient({ id: '1', name: 'Foo' }, function(e, o) {
+          server.serializeClient({ id: '1', name: 'Foo' }, {}, function(e, o) {
             err = e;
             obj = o;
             return done();
@@ -120,7 +120,7 @@ describe('Server', function() {
         var obj, err;
     
         before(function(done) {
-          server.serializeClient({ id: '1', name: 'Foo' }, function(e, o) {
+          server.serializeClient({ id: '1', name: 'Foo' }, {}, function(e, o) {
             err = e;
             obj = o;
             return done();
@@ -145,7 +145,7 @@ describe('Server', function() {
         var obj, err;
     
         before(function(done) {
-          server.deserializeClient('1', function(e, o) {
+          server.deserializeClient('1', {}, function(e, o) {
             err = e;
             obj = o;
             return done();
@@ -169,7 +169,7 @@ describe('Server', function() {
         var obj, err;
     
         before(function(done) {
-          server.deserializeClient('1', function(e, o) {
+          server.deserializeClient('1', {}, function(e, o) {
             err = e;
             obj = o;
             return done();
@@ -202,7 +202,7 @@ describe('Server', function() {
         var obj, err;
     
         before(function(done) {
-          server.deserializeClient('1', function(e, o) {
+          server.deserializeClient('1', {}, function(e, o) {
             err = e;
             obj = o;
             return done();
@@ -229,7 +229,7 @@ describe('Server', function() {
         var obj, err;
     
         before(function(done) {
-          server.deserializeClient('1', function(e, o) {
+          server.deserializeClient('1', {}, function(e, o) {
             err = e;
             obj = o;
             return done();
@@ -256,7 +256,7 @@ describe('Server', function() {
         var obj, err;
     
         before(function(done) {
-          server.deserializeClient('1', function(e, o) {
+          server.deserializeClient('1', {}, function(e, o) {
             err = e;
             obj = o;
             return done();
@@ -289,7 +289,7 @@ describe('Server', function() {
         var obj, err;
     
         before(function(done) {
-          server.deserializeClient('1', function(e, o) {
+          server.deserializeClient('1', {}, function(e, o) {
             err = e;
             obj = o;
             return done();
@@ -322,7 +322,7 @@ describe('Server', function() {
         var obj, err;
     
         before(function(done) {
-          server.deserializeClient('1', function(e, o) {
+          server.deserializeClient('1', {}, function(e, o) {
             err = e;
             obj = o;
             return done();
@@ -349,7 +349,7 @@ describe('Server', function() {
         var obj, err;
     
         before(function(done) {
-          server.deserializeClient('1', function(e, o) {
+          server.deserializeClient('1', {}, function(e, o) {
             err = e;
             obj = o;
             return done();
@@ -373,7 +373,7 @@ describe('Server', function() {
         var obj, err;
     
         before(function(done) {
-          server.deserializeClient('1', function(e, o) {
+          server.deserializeClient('1', {}, function(e, o) {
             err = e;
             obj = o;
             return done();


### PR DESCRIPTION
This checks the arity of the callback functions and pass the `req` object if it has an extra parameter. This should be backwards compatible with any existing plugins.

This PR depends on jaredhanson/chai-oauth2orize-grant#1 to have the tests pass. It's similar to my existing PR on jaredhanson/passport#160.

Let me know if there's any questions!
