### PR TITLE
Expose scope to token and code authorization grants

### DIFF
--- a/lib/grant/code.js
+++ b/lib/grant/code.js
@@ -152,7 +152,9 @@ module.exports = function code(options, issue) {
     
     try {
       var arity = issue.length;
-      if (arity == 5) {
+      if (arity == 6) {
+        issue(txn.client, txn.req.redirectURI, txn.user, txn.res, txn.req.scope, issued);
+      } else if (arity == 5) {
         issue(txn.client, txn.req.redirectURI, txn.user, txn.res, issued);
       } else { // arity == 4
         issue(txn.client, txn.req.redirectURI, txn.user, issued);

--- a/lib/grant/token.js
+++ b/lib/grant/token.js
@@ -157,7 +157,9 @@ module.exports = function token(options, issue) {
     
     try {
       var arity = issue.length;
-      if (arity == 4) {
+      if (arity == 5) {
+        issue(txn.client, txn.user, txn.res, txn.req.scope, issued);
+      } else if (arity == 4) {
         issue(txn.client, txn.user, txn.res, issued);
       } else { // arity == 3
         issue(txn.client, txn.user, issued);


### PR DESCRIPTION
I need the requested scope when I'm creating the access token.

This can also be implemented by storing the scope in the session before rendering the dialog and retrieving it in the decision parser, but since oauth2orize already do this, why not just expose it?

I expects you want some documentation and tests. Will look at that after approval.

Also, maybe exposing `txn.req` is better?
