### PR TITLE
Added event handler check for custom errors

### DIFF
--- a/lib/middleware/errorHandler.js
+++ b/lib/middleware/errorHandler.js
@@ -50,6 +50,16 @@ module.exports = function(options) {
     , fragment = options.fragment || ['token'];
   
   return function errorHandler(err, req, res, next) {
+    if (!err.name || (
+        err.name !== 'AuthorizationError' &&
+        err.name !== 'BadRequestError' &&
+        err.name !== 'ForbiddenError' &&
+        err.name !== 'TokenError')) {
+      // Not an OAuth error
+      // Probably a bug in the code implementing OAuth2orize, so we'll pass it back
+      return next(err);
+    }
+
     if (mode == 'direct') {
       if (err.status) { res.statusCode = err.status; }
       if (!res.statusCode || res.statusCode < 400) { res.statusCode = 500; }


### PR DESCRIPTION
If the underlying code (that's implementing OAuth2orize) throws an error, OAuth2orize will intercept this error and relay it back to the client. This is good for OAuth errors, but if the error is a bug in the underlying code, all means of debugging/logging is lost. For this reason I've added a check to see if the error is an OAuth error. If it's not, it'll be passed on to the next middleware.
