### PR TITLE
Added enhanceRequest option in grant parsing functions

### DIFF
--- a/lib/middleware/authorization.js
+++ b/lib/middleware/authorization.js
@@ -130,11 +130,11 @@ module.exports = function(server, options, validate, immediate) {
         if (client) { req.oauth2.client = client; }
         if (redirectURI) { req.oauth2.redirectURI = redirectURI; }
         
-        if (err) { return next(err); }
-        if (!client) { return next(new AuthorizationError('Unauthorized client', 'unauthorized_client')); }
-
         req.oauth2.req = areq;
         req.oauth2.user = req[userProperty];
+
+        if (err) { return next(err); }
+        if (!client) { return next(new AuthorizationError('Unauthorized client', 'unauthorized_client')); }
 
         function immediated(err, allow, ares) {
           if (err) { return next(err); }


### PR DESCRIPTION
Basically I needed a way to parse extra parameters in the grant request and store them in the `oauth2.req` object. The other way I found to do that was to override the parsing method, but it's ugly.

Moreover, I needed these parameters in the `next` function of `validate` in the `authorization` module, for error handling. So I moved the `req.oauth2.req = areq` just before the next.
