### PR TITLE
Fixed #86. Carry parameters set in scope checking further along

### DIFF
--- a/lib/middleware/authorization.js
+++ b/lib/middleware/authorization.js
@@ -136,11 +136,11 @@ module.exports = function(server, options, validate, immediate) {
         req.oauth2.req = areq;
         req.oauth2.user = req[userProperty];
 
-        function immediated(err, allow, ares) {
-          req.oauth2.res = ares || {};
-
+        function immediated(err, allow, info) {
           if (err) { return next(err); }
           if (allow) {
+            req.oauth2.res = info || {};
+            req.oauth2.info = info;
             req.oauth2.res.allow = true;
 
             server._respond(req.oauth2, res, function(err) {
@@ -163,7 +163,7 @@ module.exports = function(server, options, validate, immediate) {
               txn.client = obj;
               txn.redirectURI = redirectURI;
               txn.req = areq;
-              txn.res = ares;
+              txn.info = info;
               // store transaction in session
               var txns = req.session[key] = req.session[key] || {};
               txns[tid] = txn;

--- a/lib/middleware/authorization.js
+++ b/lib/middleware/authorization.js
@@ -137,10 +137,11 @@ module.exports = function(server, options, validate, immediate) {
         req.oauth2.user = req[userProperty];
 
         function immediated(err, allow, info) {
+          req.oauth2.info = info;
+
           if (err) { return next(err); }
           if (allow) {
             req.oauth2.res = info || {};
-            req.oauth2.info = info;
             req.oauth2.res.allow = true;
 
             server._respond(req.oauth2, res, function(err) {

--- a/lib/middleware/authorization.js
+++ b/lib/middleware/authorization.js
@@ -137,9 +137,10 @@ module.exports = function(server, options, validate, immediate) {
         req.oauth2.user = req[userProperty];
 
         function immediated(err, allow, ares) {
+          req.oauth2.res = ares || {};
+
           if (err) { return next(err); }
           if (allow) {
-            req.oauth2.res = ares || {};
             req.oauth2.res.allow = true;
 
             server._respond(req.oauth2, res, function(err) {
@@ -162,6 +163,7 @@ module.exports = function(server, options, validate, immediate) {
               txn.client = obj;
               txn.redirectURI = redirectURI;
               txn.req = areq;
+              txn.res = ares;
               // store transaction in session
               var txns = req.session[key] = req.session[key] || {};
               txns[tid] = txn;

--- a/lib/middleware/decision.js
+++ b/lib/middleware/decision.js
@@ -86,14 +86,13 @@ module.exports = function(server, options, parse) {
     if (!req.session[key]) { return next(new ForbiddenError('Unable to load OAuth 2.0 transactions from session')); }
     
     var tid = req.oauth2.transactionID;
-    req.oauth2.res = req.session[key][tid].res || {};
-    req.oauth2.res.body = req.body;
+    req.oauth2.info = req.session[key][tid].info;
 
     parse(req, function(err, ares) {
       if (err) { return next(err); }
     
       req.oauth2.user = req[userProperty];
-      req.oauth2.res = ares || req.oauth2.res;
+      req.oauth2.res = ares || req.oauth2.info || {};
       
       if (req.oauth2.res.allow === undefined) {
         if (!req.body[cancelField]) { req.oauth2.res.allow = true; }

--- a/lib/middleware/decision.js
+++ b/lib/middleware/decision.js
@@ -85,12 +85,10 @@ module.exports = function(server, options, parse) {
     if (!req.oauth2) { return next(new Error('OAuth2orize requires transaction support. Did you forget oauth2orize.transactionLoader(...)?')); }
     if (!req.session[key]) { return next(new ForbiddenError('Unable to load OAuth 2.0 transactions from session')); }
     
-    var tid = req.oauth2.transactionID;
-    req.oauth2.info = req.session[key][tid].info;
-
     parse(req, function(err, ares) {
       if (err) { return next(err); }
     
+      var tid = req.oauth2.transactionID;
       req.oauth2.user = req[userProperty];
       req.oauth2.res = ares || req.oauth2.info || {};
       

--- a/lib/middleware/decision.js
+++ b/lib/middleware/decision.js
@@ -85,12 +85,15 @@ module.exports = function(server, options, parse) {
     if (!req.oauth2) { return next(new Error('OAuth2orize requires transaction support. Did you forget oauth2orize.transactionLoader(...)?')); }
     if (!req.session[key]) { return next(new ForbiddenError('Unable to load OAuth 2.0 transactions from session')); }
     
+    var tid = req.oauth2.transactionID;
+    req.oauth2.res = req.session[key][tid].res || {};
+    req.oauth2.res.body = req.body;
+
     parse(req, function(err, ares) {
       if (err) { return next(err); }
     
-      var tid = req.oauth2.transactionID;
       req.oauth2.user = req[userProperty];
-      req.oauth2.res = ares || {};
+      req.oauth2.res = ares || req.oauth2.res;
       
       if (req.oauth2.res.allow === undefined) {
         if (!req.body[cancelField]) { req.oauth2.res.allow = true; }

--- a/lib/middleware/transactionLoader.js
+++ b/lib/middleware/transactionLoader.js
@@ -59,6 +59,7 @@ module.exports = function(server, options) {
       req.oauth2.client = client;
       req.oauth2.redirectURI = txn.redirectURI;
       req.oauth2.req = txn.req;
+      req.oauth2.info = txn.info;
       next();
     });
   };


### PR DESCRIPTION
Fix https://github.com/jaredhanson/oauth2orize/issues/86 by allowing results of scope checking to pass all the way through to the grant code callback by default.

Also, the callback may inspect the decision request body if needed.