### PR TITLE
Pass arbitrary data (such as scope) via 'info'

### DIFF
--- a/lib/middleware/authorization.js
+++ b/lib/middleware/authorization.js
@@ -136,10 +136,12 @@ module.exports = function(server, options, validate, immediate) {
         req.oauth2.req = areq;
         req.oauth2.user = req[userProperty];
 
-        function immediated(err, allow, ares) {
+        function immediated(err, allow, info) {
+          req.oauth2.info = info;
+
           if (err) { return next(err); }
           if (allow) {
-            req.oauth2.res = ares || {};
+            req.oauth2.res = info || {};
             req.oauth2.res.allow = true;
 
             server._respond(req.oauth2, res, function(err) {
@@ -162,6 +164,7 @@ module.exports = function(server, options, validate, immediate) {
               txn.client = obj;
               txn.redirectURI = redirectURI;
               txn.req = areq;
+              txn.info = info;
               // store transaction in session
               var txns = req.session[key] = req.session[key] || {};
               txns[tid] = txn;

--- a/lib/middleware/authorization.js
+++ b/lib/middleware/authorization.js
@@ -137,8 +137,6 @@ module.exports = function(server, options, validate, immediate) {
         req.oauth2.user = req[userProperty];
 
         function immediated(err, allow, info) {
-          req.oauth2.info = info;
-
           if (err) { return next(err); }
           if (allow) {
             req.oauth2.res = info || {};
@@ -158,6 +156,7 @@ module.exports = function(server, options, validate, immediate) {
 
               var tid = utils.uid(lenTxnID);
               req.oauth2.transactionID = tid;
+              req.oauth2.info = info;
 
               var txn = {};
               txn.protocol = 'oauth2';

--- a/lib/middleware/decision.js
+++ b/lib/middleware/decision.js
@@ -90,7 +90,7 @@ module.exports = function(server, options, parse) {
     
       var tid = req.oauth2.transactionID;
       req.oauth2.user = req[userProperty];
-      req.oauth2.res = ares || req.oauth2.info || {};
+      req.oauth2.res = ares || {};
       
       if (req.oauth2.res.allow === undefined) {
         if (!req.body[cancelField]) { req.oauth2.res.allow = true; }

--- a/lib/middleware/decision.js
+++ b/lib/middleware/decision.js
@@ -90,7 +90,7 @@ module.exports = function(server, options, parse) {
     
       var tid = req.oauth2.transactionID;
       req.oauth2.user = req[userProperty];
-      req.oauth2.res = ares || {};
+      req.oauth2.res = ares || req.oauth2.info || {};
       
       if (req.oauth2.res.allow === undefined) {
         if (!req.body[cancelField]) { req.oauth2.res.allow = true; }

--- a/lib/middleware/transactionLoader.js
+++ b/lib/middleware/transactionLoader.js
@@ -59,6 +59,7 @@ module.exports = function(server, options) {
       req.oauth2.client = client;
       req.oauth2.redirectURI = txn.redirectURI;
       req.oauth2.req = txn.req;
+      req.oauth2.info = txn.info;
       next();
     });
   };


### PR DESCRIPTION
Until this is merged it can be installed with

```bash
npm install --save coolaj86/oauth2orize.git#v1.0.1+scope.1
```