### PR TITLE
inherits all errors from a base class

### DIFF
--- a/lib/errors/authorizationerror.js
+++ b/lib/errors/authorizationerror.js
@@ -1,4 +1,9 @@
 /**
+ * Module dependencies.
+ */
+var Oauth2Error = require('./oauth2error');
+
+/**
  * `AuthorizationError` error.
  *
  * @api public
@@ -15,7 +20,7 @@ function AuthorizationError(message, code, uri, status) {
     }
   }
   
-  Error.call(this);
+  Oauth2Error.call(this);
   Error.captureStackTrace(this, arguments.callee);
   this.name = 'AuthorizationError';
   this.message = message;
@@ -25,9 +30,9 @@ function AuthorizationError(message, code, uri, status) {
 }
 
 /**
- * Inherit from `Error`.
+ * Inherit from `Oauth2Error`.
  */
-AuthorizationError.prototype.__proto__ = Error.prototype;
+AuthorizationError.prototype.__proto__ = Oauth2Error.prototype;
 
 
 /**

--- a/lib/errors/badrequesterror.js
+++ b/lib/errors/badrequesterror.js
@@ -1,10 +1,15 @@
 /**
+ * Module dependencies.
+ */
+var Oauth2Error = require('./oauth2error');
+
+/**
  * `BadRequestError` error.
  *
  * @api public
  */
 function BadRequestError(message) {
-  Error.call(this);
+  Oauth2Error.call(this);
   Error.captureStackTrace(this, arguments.callee);
   this.name = 'BadRequestError';
   this.message = message;
@@ -12,9 +17,9 @@ function BadRequestError(message) {
 }
 
 /**
- * Inherit from `Error`.
+ * Inherit from `Oauth2Error`.
  */
-BadRequestError.prototype.__proto__ = Error.prototype;
+BadRequestError.prototype.__proto__ = Oauth2Error.prototype;
 
 
 /**

--- a/lib/errors/forbiddenerror.js
+++ b/lib/errors/forbiddenerror.js
@@ -1,10 +1,15 @@
 /**
+ * Module dependencies.
+ */
+var Oauth2Error = require('./oauth2error');
+
+/**
  * `ForbiddenError` error.
  *
  * @api public
  */
 function ForbiddenError(message) {
-  Error.call(this);
+  Oauth2Error.call(this);
   Error.captureStackTrace(this, arguments.callee);
   this.name = 'ForbiddenError';
   this.message = message;
@@ -12,9 +17,9 @@ function ForbiddenError(message) {
 }
 
 /**
- * Inherit from `Error`.
+ * Inherit from `Oauth2Error`.
  */
-ForbiddenError.prototype.__proto__ = Error.prototype;
+ForbiddenError.prototype.__proto__ = Oauth2Error.prototype;
 
 
 /**

--- a/lib/errors/oauth2error.js
+++ b/lib/errors/oauth2error.js
@@ -1,0 +1,19 @@
+/**
+ * `Oauth2Error` error.
+ *
+ * @api public
+ */
+function Oauth2Error(message) {
+  Error.call(this);
+}
+
+/**
+ * Inherit from `Error`.
+ */
+Oauth2Error.prototype.__proto__ = Error.prototype;
+
+
+/**
+ * Expose `Oauth2Error`.
+ */
+module.exports = Oauth2Error;

--- a/lib/errors/tokenerror.js
+++ b/lib/errors/tokenerror.js
@@ -1,4 +1,9 @@
 /**
+ * Module dependencies.
+ */
+var Oauth2Error = require('./oauth2error');
+
+/**
  * `TokenError` error.
  *
  * @api public
@@ -15,7 +20,7 @@ function TokenError(message, code, uri, status) {
     }
   }
   
-  Error.call(this);
+  Oauth2Error.call(this);
   Error.captureStackTrace(this, arguments.callee);
   this.name = 'TokenError';
   this.message = message;
@@ -25,9 +30,9 @@ function TokenError(message, code, uri, status) {
 }
 
 /**
- * Inherit from `Error`.
+ * Inherit from `Oauth2Error`.
  */
-TokenError.prototype.__proto__ = Error.prototype;
+TokenError.prototype.__proto__ = Oauth2Error.prototype;
 
 
 /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -67,5 +67,8 @@ exports.exchange.code = exports.exchange.authorizationCode;
 /**
  * Export errors.
  */
+exports.Oauth2Error = require('./errors/oauth2error');
 exports.AuthorizationError = require('./errors/authorizationerror');
+exports.BadRequestError = require('./errors/badrequesterror');
+exports.ForbiddenError = require('./errors/forbiddenerror');
 exports.TokenError = require('./errors/tokenerror');

--- a/test/errors/oauth2error.test.js
+++ b/test/errors/oauth2error.test.js
@@ -1,0 +1,41 @@
+var Oauth2Error = require('../../lib/errors/oauth2error')
+  , AuthorizationError = require('../../lib/errors/authorizationerror')
+  , BadRequestError = require('../../lib/errors/badrequesterror')
+  , ForbiddenError = require('../../lib/errors/forbiddenerror')
+  , TokenError = require('../../lib/errors/tokenerror');
+
+
+describe('Oauth2Error', function() {
+  describe('AuthorizationError', function () {
+    var err = new AuthorizationError();
+    it('should inherits from Oauth2Error and Error', function() {
+      expect(err).to.be.instanceof(Oauth2Error);
+      expect(err).to.be.instanceof(Error);
+    });
+  });
+
+  describe('BadRequestError', function () {
+    var err = new BadRequestError();
+    it('should inherits from Oauth2Error and Error', function() {
+      expect(err).to.be.instanceof(Oauth2Error);
+      expect(err).to.be.instanceof(Error);
+    });
+  });
+
+  describe('ForbiddenError', function () {
+    var err = new ForbiddenError();
+    it('should inherits from Oauth2Error and Error', function() {
+      expect(err).to.be.instanceof(Oauth2Error);
+      expect(err).to.be.instanceof(Error);
+    });
+  });
+
+  describe('TokenError', function () {
+    var err = new TokenError();
+    it('should inherits from Oauth2Error and Error', function() {
+      expect(err).to.be.instanceof(Oauth2Error);
+      expect(err).to.be.instanceof(Error);
+    });
+  });
+
+});


### PR DESCRIPTION
This makes it easy to check if an error is originating from oauth2orize.

Now I'm adding the following middleware before oauth2orizes error handler middleware:

```js
function (err, req, res, next) {
  req.log.error({ err: err })
  if (!(err instanceof Oauth2Error)) {
    err = { statusCode: 500, message: 'internal error' }
  }
  next(err)
}
```

Related to #80