### PR TITLE
implement immediate query flag

### DIFF
--- a/lib/grant/token.js
+++ b/lib/grant/token.js
@@ -84,7 +84,8 @@ module.exports = function token(options, issue) {
     var clientID = req.query.client_id
       , redirectURI = req.query.redirect_uri
       , scope = req.query.scope
-      , state = req.query.state;
+      , state = req.query.state
+      , immediate = req.query.immediate === 'true';
       
     if (!clientID) { throw new AuthorizationError('Missing required parameter: client_id', 'invalid_request'); }
     
@@ -106,7 +107,8 @@ module.exports = function token(options, issue) {
       clientID: clientID,
       redirectURI: redirectURI,
       scope: scope,
-      state: state
+      state: state,
+      immediate: immediate
     };
   }
   

--- a/lib/middleware/authorization.js
+++ b/lib/middleware/authorization.js
@@ -136,6 +136,11 @@ module.exports = function(server, options, validate, immediate) {
         req.oauth2.req = areq;
         req.oauth2.user = req[userProperty];
 
+        if (areq.immediate && !req.oauth2.user) {
+          next(new AuthorizationError('', 'immediate_unsuccessful'));
+          return;
+        }
+
         function immediated(err, allow, ares) {
           if (err) { return next(err); }
           if (allow) {
@@ -146,6 +151,8 @@ module.exports = function(server, options, validate, immediate) {
               if (err) { return next(err); }
               return next(new AuthorizationError('Unsupported response type: ' + req.oauth2.req.type, 'unsupported_response_type'));
             });
+          } else if (areq.immediate) {
+            next(new AuthorizationError('', 'immediate_unsuccessful'));
           } else {
             // A dialog needs to be conducted to obtain the user's approval.
             // Serialize a transaction to the session.  The transaction will be


### PR DESCRIPTION
I know this is not in the spec, but this is the easiest way to implement support for it. Also it could be useful for others.

The only other solution i saw was to split the validation and immediate code handling into two different middlewares.

It is based on SalesForce's documentation [1].

The use case is that I want to do the authorization in a hidden iframe and only fallback to redirect if it fails.

For reference, I'm using it like the following code.

I don't think the `x-frame-options` part should be part of `oauth2orize`.

``` js
module.exports =
  [ function (req, res, next) {
      if (req.query.immediate === 'true') {
        res.removeHeader('x-frame-options')
      }
      next()
    }
  , server.authorize(validate, immediate)
  , ensureLoggedIn()
  , renderDialog
  , server.errorHandler({ mode: 'indirect' })
  ]
```

[1] https://help.salesforce.com/HTViewHelpDoc?id=remoteaccess_oauth_web_server_flow.htm&language=en_US
