### PR TITLE
grant: support response_mode as optional parameter

### DIFF
--- a/lib/grant/code.js
+++ b/lib/grant/code.js
@@ -2,6 +2,7 @@
  * Module dependencies.
  */
 var url = require('url')
+  , responseMode = require('../responseMode')
   , AuthorizationError = require('../errors/authorizationerror');
 
 
@@ -84,7 +85,8 @@ module.exports = function code(options, issue) {
     var clientID = req.query.client_id
       , redirectURI = req.query.redirect_uri
       , scope = req.query.scope
-      , state = req.query.state;
+      , state = req.query.state
+      , responseMode = req.query.response_mode;
       
     if (!clientID) { throw new AuthorizationError('Missing required parameter: client_id', 'invalid_request'); }
     
@@ -106,7 +108,8 @@ module.exports = function code(options, issue) {
       clientID: clientID,
       redirectURI: redirectURI,
       scope: scope,
-      state: state
+      state: state,
+      responseMode: responseMode
     };
   }
   
@@ -119,27 +122,29 @@ module.exports = function code(options, issue) {
    */
   function response(txn, res, next) {
     if (!txn.redirectURI) { return next(new Error('Unable to issue redirect for OAuth 2.0 transaction')); }
+
+    function sendResult(params) {
+      if (txn.req && txn.req.state) {
+        params.state = txn.req.state;
+      }
+
+      // the default Response Mode for the OAuth 2.0 code Response Type is the 'query' encoding
+      var applyResponse = responseMode[(txn.req && txn.req.responseMode) || 'query'];
+      if (!applyResponse) { return next(new AuthorizationError('Unsupported response mode: ' + txn.req.responseMode, 'unsupported_response_mode')); }
+      return applyResponse(res, txn.redirectURI, params);
+    }
+
     if (!txn.res.allow) {
-      var parsed = url.parse(txn.redirectURI, true);
-      delete parsed.search;
-      parsed.query.error = 'access_denied';
-      if (txn.req && txn.req.state) { parsed.query.state = txn.req.state; }
-      
-      var location = url.format(parsed);
-      return res.redirect(location);
+      var err = { error: 'access_denied' };
+      return sendResult(err);
     }
     
     function issued(err, code) {
       if (err) { return next(err); }
       if (!code) { return next(new AuthorizationError('Request denied by authorization server', 'access_denied')); }
       
-      var parsed = url.parse(txn.redirectURI, true);
-      delete parsed.search;
-      parsed.query.code = code;
-      if (txn.req && txn.req.state) { parsed.query.state = txn.req.state; }
-      
-      var location = url.format(parsed);
-      return res.redirect(location);
+      var params = { code: code };
+      return sendResult(params);
     }
     
     // NOTE: The `redirect_uri`, if present in the client's authorization

--- a/lib/grant/token.js
+++ b/lib/grant/token.js
@@ -4,6 +4,7 @@
 var url = require('url')
   , qs = require('querystring')
   , utils = require('../utils')
+  , responseMode = require('../responseMode')
   , AuthorizationError = require('../errors/authorizationerror');
 
 
@@ -84,7 +85,8 @@ module.exports = function token(options, issue) {
     var clientID = req.query.client_id
       , redirectURI = req.query.redirect_uri
       , scope = req.query.scope
-      , state = req.query.state;
+      , state = req.query.state
+      , responseMode = req.query.response_mode;
       
     if (!clientID) { throw new AuthorizationError('Missing required parameter: client_id', 'invalid_request'); }
     
@@ -106,7 +108,8 @@ module.exports = function token(options, issue) {
       clientID: clientID,
       redirectURI: redirectURI,
       scope: scope,
-      state: state
+      state: state,
+      responseMode: responseMode
     };
   }
   
@@ -119,16 +122,21 @@ module.exports = function token(options, issue) {
    */
   function response(txn, res, next) {
     if (!txn.redirectURI) { return next(new Error('Unable to issue redirect for OAuth 2.0 transaction')); }
+
+    function sendResult(params) {
+      if (txn.req && txn.req.state) {
+        params.state = txn.req.state;
+      }
+
+      // the default Response Mode for the OAuth 2.0 token Response Type is the 'fragment' encoding
+      var applyResponse = responseMode[(txn.req && txn.req.responseMode) || 'fragment'];
+      if (!applyResponse) { return next(new AuthorizationError('Unsupported response mode: ' + txn.req.responseMode, 'unsupported_response_mode')); }
+      return applyResponse(res, txn.redirectURI, params);
+    }
+
     if (!txn.res.allow) {
-      var err = {};
-      err.error = 'access_denied';
-      if (txn.req && txn.req.state) { err.state = txn.req.state; }
-      
-      var parsed = url.parse(txn.redirectURI);
-      parsed.hash = qs.stringify(err);
-      
-      var location = url.format(parsed);
-      return res.redirect(location);
+      var err = { error: 'access_denied' };
+      return sendResult(err);
     }
     
     function issued(err, accessToken, params) {
@@ -139,13 +147,8 @@ module.exports = function token(options, issue) {
       tok.access_token = accessToken;
       if (params) { utils.merge(tok, params); }
       tok.token_type = tok.token_type || 'Bearer';
-      if (txn.req && txn.req.state) { tok.state = txn.req.state; }
-      
-      var parsed = url.parse(txn.redirectURI);
-      parsed.hash = qs.stringify(tok);
-      
-      var location = url.format(parsed);
-      return res.redirect(location);
+
+      return sendResult(tok);
     }
     
     // NOTE: In contrast to an authorization code grant, redirectURI is not

--- a/lib/responseMode/form_post.js
+++ b/lib/responseMode/form_post.js
@@ -1,0 +1,34 @@
+/**
+* Authorization Response parameters are encoded as HTML form values that are auto-submitted in the User Agent, 
+* and thus are transmitted via the HTTP POST method to the Client, with the result parameters being encoded in 
+* the response body using the application/x-www-form-urlencoded format. The action attribute of the form MUST be 
+* the Client's Redirection URI. The method of the form attribute MUST be POST.
+* Any technique supported by the User Agent MAY be used to cause the submission of the form, and any form content 
+* necessary to support this MAY be included, such as submit controls and client-side scripting commands. However, 
+* the Client MUST be able to process the message without regard for the mechanism by which the form submission was 
+* initiated. (http://openid.net/specs/oauth-v2-form-post-response-mode-1_0-01.html)
+**/
+
+var input = '<input type="hidden" name="{NAME}" value="{VALUE}"/>';
+var html = '<html>' +
+  '<head><title>Submit This Form</title></head>' +
+  '<body onload="javascript:document.forms[0].submit()">' +
+    '<form method="post" action="{ACTION}">' +
+      '{INPUTS}' +
+    '</form>' +
+  '</body>' +
+'</html>';
+
+module.exports = function (res, redirectURI, params) {
+  var inputs = [];
+  
+  Object.keys(params || {}).forEach(function (k) {
+    inputs.push(input.replace('{NAME}', k).replace('{VALUE}', params[k]));
+   });
+
+  res.setHeader('Content-Type', 'text/html;charset=UTF-8');
+  res.setHeader('Cache-Control', 'no-store');
+  res.setHeader('Pragma', 'no-cache');
+
+  return res.end(html.replace('{ACTION}', redirectURI).replace('{INPUTS}', inputs.join('')));
+};

--- a/lib/responseMode/fragment.js
+++ b/lib/responseMode/fragment.js
@@ -1,0 +1,14 @@
+var url = require('url')
+  , qs = require('querystring');
+
+/**
+* Authorization Response parameters are encoded in the fragment added to the redirect_uri when 
+* redirecting back to the Client.
+**/
+module.exports = function (res, redirectURI, params) {
+  var parsed = url.parse(redirectURI);
+  parsed.hash = qs.stringify(params || {});
+
+  var location = url.format(parsed);
+  return res.redirect(location);
+};

--- a/lib/responseMode/index.js
+++ b/lib/responseMode/index.js
@@ -1,0 +1,3 @@
+exports.form_post = require('./form_post');
+exports.fragment = require('./fragment');
+exports.query = require('./query');

--- a/lib/responseMode/query.js
+++ b/lib/responseMode/query.js
@@ -1,0 +1,17 @@
+var url = require('url');
+
+/**
+* Authorization Response parameters are encoded in the query string added to the redirect_uri when 
+* redirecting back to the Client.
+**/
+module.exports = function (res, redirectURI, params) {
+  var parsed = url.parse(redirectURI, true);
+  delete parsed.search;
+
+  Object.keys(params || {}).forEach(function (k) {
+    parsed.query[k] = params[k];
+  });
+
+  var location = url.format(parsed);
+  return res.redirect(location);
+};

--- a/test/grant/code.test.js
+++ b/test/grant/code.test.js
@@ -529,5 +529,180 @@ describe('grant.code', function() {
       });
     });
   });
+
+  describe('responseMode.form_post', function () {
+    function issue(client, redirectURI, user, done) {
+      if (client.id == 'c123' && redirectURI == 'http://example.com/auth/callback' && user.id == 'u123') {
+        return done(null, 'xyz');
+      } else if (client.id == 'cUNAUTHZ') {
+        return done(null, false);
+      } else if (client.id == 'cTHROW') {
+        throw new Error('something was thrown');
+      }
+      return done(new Error('something went wrong'));
+    }
+
+    describe('transaction', function() {
+      var response;
+      
+      before(function(done) {
+        chai.oauth2orize.grant(code(issue))
+          .txn(function(txn) {
+            txn.client = { id: 'c123', name: 'Example' };
+            txn.redirectURI = 'http://www.example.com/auth/callback';
+            txn.req = {
+              redirectURI: 'http://example.com/auth/callback',
+              responseMode: 'form_post'
+            };
+            txn.user = { id: 'u123', name: 'Bob' };
+            txn.res = { allow: true };
+          })
+          .end(function(res) {
+            response = res;
+            done();
+          })
+          .decide();
+      });
+      
+      it('should respond', function() {
+        expect(response.statusCode).to.equal(200);
+        expect(response.getHeader('Content-Type')).to.equal('text/html;charset=UTF-8');
+        expect(response.getHeader('Cache-Control')).to.equal('no-store');
+        expect(response.getHeader('Pragma')).to.equal('no-cache');
+        expect(response._data).to.have.string('<form method="post" action="http://www.example.com/auth/callback">');
+        expect(response._data).to.have.string('<input type="hidden" name="code" value="xyz"/>');
+      });
+    });
+
+    describe('transaction with request state', function() {
+      var response;
+      
+      before(function(done) {
+        chai.oauth2orize.grant(code(issue))
+          .txn(function(txn) {
+            txn.client = { id: 'c123', name: 'Example' };
+            txn.redirectURI = 'http://www.example.com/auth/callback';
+            txn.req = {
+              redirectURI: 'http://example.com/auth/callback',
+              state: 'f1o1o1',
+              responseMode: 'form_post'
+            };
+            txn.user = { id: 'u123', name: 'Bob' };
+            txn.res = { allow: true };
+          })
+          .end(function(res) {
+            response = res;
+            done();
+          })
+          .decide();
+      });
+      
+      it('should respond', function() {
+        expect(response.statusCode).to.equal(200);
+        expect(response.getHeader('Content-Type')).to.equal('text/html;charset=UTF-8');
+        expect(response.getHeader('Cache-Control')).to.equal('no-store');
+        expect(response.getHeader('Pragma')).to.equal('no-cache');
+        expect(response._data).to.have.string('<form method="post" action="http://www.example.com/auth/callback">');
+        expect(response._data).to.have.string('<input type="hidden" name="code" value="xyz"/>');
+        expect(response._data).to.have.string('<input type="hidden" name="state" value="f1o1o1"/>');
+      });
+    });
+    
+    describe('disallowed transaction', function() {
+      var response;
+      
+      before(function(done) {
+        chai.oauth2orize.grant(code(issue))
+          .txn(function(txn) {
+            txn.client = { id: 'c123', name: 'Example' };
+            txn.redirectURI = 'http://www.example.com/auth/callback';
+            txn.req = {
+              redirectURI: 'http://example.com/auth/callback',
+              responseMode: 'form_post'
+            };
+            txn.user = { id: 'u123', name: 'Bob' };
+            txn.res = { allow: false };
+          })
+          .end(function(res) {
+            response = res;
+            done();
+          })
+          .decide();
+      });
+      
+      it('should respond', function() {
+        expect(response.statusCode).to.equal(200);
+        expect(response.getHeader('Content-Type')).to.equal('text/html;charset=UTF-8');
+        expect(response.getHeader('Cache-Control')).to.equal('no-store');
+        expect(response.getHeader('Pragma')).to.equal('no-cache');
+        expect(response._data).to.have.string('<form method="post" action="http://www.example.com/auth/callback">');
+        expect(response._data).to.have.string('<input type="hidden" name="error" value="access_denied"/>');
+      });
+    });
+    
+    describe('disallowed transaction with request state', function() {
+      var response;
+      
+      before(function(done) {
+        chai.oauth2orize.grant(code(issue))
+          .txn(function(txn) {
+            txn.client = { id: 'c123', name: 'Example' };
+            txn.redirectURI = 'http://www.example.com/auth/callback';
+            txn.req = {
+              redirectURI: 'http://example.com/auth/callback',
+              state: 'f2o2o2',
+              responseMode: 'form_post'
+            };
+            txn.user = { id: 'u123', name: 'Bob' };
+            txn.res = { allow: false };
+          })
+          .end(function(res) {
+            response = res;
+            done();
+          })
+          .decide();
+      });
+      
+      it('should respond', function() {
+        expect(response.statusCode).to.equal(200);
+        expect(response.getHeader('Content-Type')).to.equal('text/html;charset=UTF-8');
+        expect(response.getHeader('Cache-Control')).to.equal('no-store');
+        expect(response.getHeader('Pragma')).to.equal('no-cache');
+        expect(response._data).to.have.string('<form method="post" action="http://www.example.com/auth/callback">');
+        expect(response._data).to.have.string('<input type="hidden" name="error" value="access_denied"/>');
+        expect(response._data).to.have.string('<input type="hidden" name="state" value="f2o2o2"/>');
+      });
+    });
+
+    describe('transaction with unsupported responseMode', function() {
+      var err;
+      
+      before(function(done) {
+        chai.oauth2orize.grant(code(issue))
+          .txn(function(txn) {
+            txn.client = { id: 'c123', name: 'Example' };
+            txn.redirectURI = 'http://www.example.com/auth/callback';
+            txn.req = {
+              redirectURI: 'http://example.com/auth/callback',
+              responseMode: 'invalid_mode'
+            };
+            txn.user = { id: 'u123', name: 'Bob' };
+            txn.res = { allow: true };
+          })
+          .next(function(e) {
+            err = e;
+            done();
+          })
+          .decide();
+      });
+      
+      it('should respond', function() {
+        expect(err).to.be.an.instanceOf(Error);
+        expect(err.constructor.name).to.equal('AuthorizationError');
+        expect(err.message).to.equal('Unsupported response mode: invalid_mode');
+        expect(err.code).to.equal('unsupported_response_mode');
+      });
+    });
+  });
   
 });

--- a/test/grant/token.test.js
+++ b/test/grant/token.test.js
@@ -588,4 +588,185 @@ describe('grant.token', function() {
     });
   });
 
+  describe('responseMode.form_post', function () {
+    function issue(client, user, done) {
+      if (client.id == 'c123' && user.id == 'u123') {
+        return done(null, 'xyz');
+      } else if (client.id == 'c223' && user.id == 'u123') {
+        return done(null, 'xyz', { 'expires_in': 3600 });
+      } else if (client.id == 'c323' && user.id == 'u123') {
+        return done(null, 'xyz', { 'token_type': 'foo', 'expires_in': 3600 });
+      } else if (client.id == 'cUNAUTHZ') {
+        return done(null, false);
+      } else if (client.id == 'cTHROW') {
+        throw new Error('something was thrown');
+      }
+      return done(new Error('something is wrong'));
+    }
+    
+    describe('transaction', function() {
+      var response;
+      
+      before(function(done) {
+        chai.oauth2orize.grant(token(issue))
+          .txn(function(txn) {
+            txn.client = { id: 'c123', name: 'Example' };
+            txn.redirectURI = 'http://example.com/auth/callback';
+            txn.req = {
+              redirectURI: 'http://example.com/auth/callback',
+              responseMode: 'form_post'
+            };
+            txn.user = { id: 'u123', name: 'Bob' };
+            txn.res = { allow: true };
+          })
+          .end(function(res) {
+            response = res;
+            done();
+          })
+          .decide();
+      });
+      
+      it('should respond', function() {
+        expect(response.statusCode).to.equal(200);
+        expect(response.getHeader('Content-Type')).to.equal('text/html;charset=UTF-8');
+        expect(response.getHeader('Cache-Control')).to.equal('no-store');
+        expect(response.getHeader('Pragma')).to.equal('no-cache');
+        expect(response._data).to.have.string('<form method="post" action="http://example.com/auth/callback">');
+        expect(response._data).to.have.string('<input type="hidden" name="access_token" value="xyz"/>');
+        expect(response._data).to.have.string('<input type="hidden" name="token_type" value="Bearer"/>');
+      });
+    });
+    
+    describe('transaction with request state', function() {
+      var response;
+      
+      before(function(done) {
+        chai.oauth2orize.grant(token(issue))
+          .txn(function(txn) {
+            txn.client = { id: 'c123', name: 'Example' };
+            txn.redirectURI = 'http://example.com/auth/callback';
+            txn.req = {
+              redirectURI: 'http://example.com/auth/callback',
+              state: 'f1o1o1',
+              responseMode: 'form_post'
+            };
+            txn.user = { id: 'u123', name: 'Bob' };
+            txn.res = { allow: true };
+          })
+          .end(function(res) {
+            response = res;
+            done();
+          })
+          .decide();
+      });
+      
+      it('should respond', function() {
+        expect(response.statusCode).to.equal(200);
+        expect(response.getHeader('Content-Type')).to.equal('text/html;charset=UTF-8');
+        expect(response.getHeader('Cache-Control')).to.equal('no-store');
+        expect(response.getHeader('Pragma')).to.equal('no-cache');
+        expect(response._data).to.have.string('<form method="post" action="http://example.com/auth/callback">');
+        expect(response._data).to.have.string('<input type="hidden" name="access_token" value="xyz"/>');
+        expect(response._data).to.have.string('<input type="hidden" name="token_type" value="Bearer"/>');
+        expect(response._data).to.have.string('<input type="hidden" name="state" value="f1o1o1"/>');
+      });
+    });
+
+    describe('disallowed transaction', function() {
+      var response;
+      
+      before(function(done) {
+        chai.oauth2orize.grant(token(issue))
+          .txn(function(txn) {
+            txn.client = { id: 'c123', name: 'Example' };
+            txn.redirectURI = 'http://example.com/auth/callback';
+            txn.req = {
+              redirectURI: 'http://example.com/auth/callback',
+              responseMode: 'form_post'
+            };
+            txn.user = { id: 'u123', name: 'Bob' };
+            txn.res = { allow: false };
+          })
+          .end(function(res) {
+            response = res;
+            done();
+          })
+          .decide();
+      });
+      
+      it('should respond', function() {
+        expect(response.statusCode).to.equal(200);
+        expect(response.getHeader('Content-Type')).to.equal('text/html;charset=UTF-8');
+        expect(response.getHeader('Cache-Control')).to.equal('no-store');
+        expect(response.getHeader('Pragma')).to.equal('no-cache');
+        expect(response._data).to.have.string('<form method="post" action="http://example.com/auth/callback">');
+        expect(response._data).to.have.string('<input type="hidden" name="error" value="access_denied"/>');
+      });
+    });
+    
+    describe('disallowed transaction with request state', function() {
+      var response;
+      
+      before(function(done) {
+        chai.oauth2orize.grant(token(issue))
+          .txn(function(txn) {
+            txn.client = { id: 'c123', name: 'Example' };
+            txn.redirectURI = 'http://example.com/auth/callback';
+            txn.req = {
+              redirectURI: 'http://example.com/auth/callback',
+              state: 'f2o2o2',
+              responseMode: 'form_post'
+            };
+            txn.user = { id: 'u123', name: 'Bob' };
+            txn.res = { allow: false };
+          })
+          .end(function(res) {
+            response = res;
+            done();
+          })
+          .decide();
+      });
+      
+      it('should respond', function() {
+        expect(response.statusCode).to.equal(200);
+        expect(response.getHeader('Content-Type')).to.equal('text/html;charset=UTF-8');
+        expect(response.getHeader('Cache-Control')).to.equal('no-store');
+        expect(response.getHeader('Pragma')).to.equal('no-cache');
+        expect(response._data).to.have.string('<form method="post" action="http://example.com/auth/callback">');
+        expect(response._data).to.have.string('<input type="hidden" name="error" value="access_denied"/>');
+        expect(response._data).to.have.string('<input type="hidden" name="state" value="f2o2o2"/>');
+      });
+    });
+
+    describe('transaction with unsupported responseMode', function() {
+      var err;
+      
+      before(function(done) {
+        chai.oauth2orize.grant(token(issue))
+          .txn(function(txn) {
+            txn.client = { id: 'c123', name: 'Example' };
+            txn.redirectURI = 'http://example.com/auth/callback';
+            txn.req = {
+              redirectURI: 'http://example.com/auth/callback',
+              responseMode: 'invalid_mode'
+            };
+            txn.user = { id: 'u123', name: 'Bob' };
+            txn.res = { allow: true };
+          })
+          .next(function(e) {
+            err = e;
+            done();
+          })
+          .decide();
+      });
+      
+      it('should error', function() {
+        expect(err).to.be.an.instanceOf(Error);
+        expect(err.constructor.name).to.equal('AuthorizationError');
+        expect(err.message).to.equal('Unsupported response mode: invalid_mode');
+        expect(err.code).to.equal('unsupported_response_mode');
+      });
+    });
+  });
+
 });


### PR DESCRIPTION
The Response Mode determines how the Authorization Server returns result parameters from the Authorization Endpoint. Non-default modes are specified using the `response_mode` request parameter.

If `response_mode` is not present in a request, the default Response Mode mechanism specified by the Response Type is used:
* The default Response Mode for the OAuth 2.0 `code` Response Type is the `query` encoding.
* The default Response Mode for the OAuth 2.0 `token` Response Type is the `fragment` encoding.

### Supported values
#### query
In this mode, Authorization Response parameters are encoded in the query string added to the redirect_uri when redirecting back to the Client.
#### fragment
In this mode, Authorization Response parameters are encoded in the fragment added to the redirect_uri when redirecting back to the Client.
#### form_post
In this mode, Authorization Response parameters are encoded as HTML form values that are auto-submitted in the User Agent, and thus are transmitted via the HTTP POST method to the Client, with the result parameters being encoded in the response body using the application/x-www-form-urlencoded format. 

More details:
* http://openid.net/specs/oauth-v2-multiple-response-types-1_0.html#ResponseModes
* http://openid.net/specs/oauth-v2-form-post-response-mode-1_0-01.html#FormPostResponseMode