### PR TITLE
fix docblocks

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -248,7 +248,7 @@ Server.prototype.deserializeClient = function(fn, done) {
  * @param {String} type
  * @param {http.ServerRequest} req
  * @param {Function} cb
- * @api private
+ * @api public
  */
 Server.prototype._parse = function(type, req, cb) {
   var ultype = new UnorderedList(type)
@@ -291,7 +291,7 @@ Server.prototype._parse = function(type, req, cb) {
  * @param {Object} txn
  * @param {http.ServerResponse} res
  * @param {Function} cb
- * @api private
+ * @api public
  */
 Server.prototype._respond = function(txn, res, cb) {
   var ultype = new UnorderedList(txn.req.type)
@@ -325,7 +325,7 @@ Server.prototype._respond = function(txn, res, cb) {
  * @param {http.ServerRequest} req
  * @param {http.ServerResponse} res
  * @param {Function} cb
- * @api private
+ * @api public
  */
 Server.prototype._exchange = function(type, req, res, cb) {
   var stack = this._exchanges


### PR DESCRIPTION
_parse, _response and _exchange server methods' visibility are public