### PR TITLE
Added custom token error description

### DIFF
--- a/lib/exchange/password.js
+++ b/lib/exchange/password.js
@@ -102,9 +102,9 @@ module.exports = function(options, issue) {
       if (!Array.isArray(scope)) { scope = [ scope ]; }
     }
     
-    function issued(err, accessToken, refreshToken, params) {
+    function issued(err, accessToken, refreshToken, params, tokenErrDescription) {
       if (err) { return next(err); }
-      if (!accessToken) { return next(new TokenError('Invalid resource owner credentials', 'invalid_grant')); }
+      if (!accessToken) { return next(new TokenError(tokenErrDescription || 'Invalid resource owner credentials', 'invalid_grant')); }
       if (refreshToken && typeof refreshToken == 'object') {
         params = refreshToken;
         refreshToken = null;


### PR DESCRIPTION
Custom error description to be used when accessToken is not set. Fixes [issue #120](https://github.com/jaredhanson/oauth2orize/issues/120)