### PR TITLE
Fix strict errors when attempting to use `arguments.callee`

### DIFF
--- a/lib/errors/authorizationerror.js
+++ b/lib/errors/authorizationerror.js
@@ -19,9 +19,9 @@ function AuthorizationError(message, code, uri, status) {
       case 'temporarily_unavailable': status = 503; break;
     }
   }
-  
+
   OAuth2Error.call(this, message, code, uri, status);
-  Error.captureStackTrace(this, arguments.callee);
+  Error.captureStackTrace(this, AuthorizationError);
   this.name = 'AuthorizationError';
 }
 

--- a/lib/errors/badrequesterror.js
+++ b/lib/errors/badrequesterror.js
@@ -5,7 +5,7 @@
  */
 function BadRequestError(message) {
   Error.call(this);
-  Error.captureStackTrace(this, arguments.callee);
+  Error.captureStackTrace(this, BadRequestError);
   this.name = 'BadRequestError';
   this.message = message;
   this.status = 400;

--- a/lib/errors/forbiddenerror.js
+++ b/lib/errors/forbiddenerror.js
@@ -5,7 +5,7 @@
  */
 function ForbiddenError(message) {
   Error.call(this);
-  Error.captureStackTrace(this, arguments.callee);
+  Error.captureStackTrace(this, ForbiddenError);
   this.name = 'ForbiddenError';
   this.message = message;
   this.status = 403;

--- a/lib/errors/tokenerror.js
+++ b/lib/errors/tokenerror.js
@@ -13,6 +13,7 @@ function TokenError(message, code, uri, status) {
     switch (code) {
       case 'invalid_request': status = 400; break;
       case 'invalid_client': status = 401; break;
+      case 'token_expired': status = 401; break;
       case 'invalid_grant': status = 403; break;
       case 'unauthorized_client': status = 403; break;
       case 'unsupported_grant_type': status = 501; break;

--- a/lib/errors/tokenerror.js
+++ b/lib/errors/tokenerror.js
@@ -19,9 +19,9 @@ function TokenError(message, code, uri, status) {
       case 'invalid_scope': status = 400; break;
     }
   }
-  
+
   OAuth2Error.call(this, message, code, uri, status);
-  Error.captureStackTrace(this, arguments.callee);
+  Error.captureStackTrace(this, TokenError);
   this.name = 'TokenError';
 }
 

--- a/lib/exchange/refreshToken.js
+++ b/lib/exchange/refreshToken.js
@@ -99,7 +99,7 @@ module.exports = function(options, issue) {
     
     function issued(err, accessToken, refreshToken, params) {
       if (err) { return next(err); }
-      if (!accessToken) { return next(new TokenError('Invalid refresh token', 'invalid_grant')); }
+      if (!accessToken) { return next(new TokenError('Token Expired', 'token_expired')); }
       if (refreshToken && typeof refreshToken == 'object') {
         params = refreshToken;
         refreshToken = null;


### PR DESCRIPTION
See https://code.google.com/p/v8-wiki/wiki/JavaScriptStackTraceApi#Stack_trace_collection_for_custom_exceptions. Fixes #134.