### PR TITLE
Implement support for response_mode

### DIFF
--- a/lib/grant/code.js
+++ b/lib/grant/code.js
@@ -130,6 +130,7 @@ module.exports = function code(options, issue) {
     }
     respond = modes[mode];
     
+    if (!respond) { return next(new AuthorizationError('Unsupported response mode: ' + mode, undefined, null, 501)); }
     if (respond && respond.validate) {
       try {
         respond.validate(txn);

--- a/lib/grant/code.js
+++ b/lib/grant/code.js
@@ -130,12 +130,17 @@ module.exports = function code(options, issue) {
     }
     respond = modes[mode];
     
-    if (!txn.redirectURI) { return next(new Error('Unable to issue redirect for OAuth 2.0 transaction')); }
+    if (respond && respond.validate) {
+      try {
+        respond.validate(txn);
+      } catch(ex) {
+        return next(ex);
+      }
+    }
+    
     if (!txn.res.allow) {
       var params = { error: 'access_denied' };
       if (txn.req && txn.req.state) { params.state = txn.req.state; }
-      
-      // TODO: Catch exceptions
       return respond(txn, res, params);
     }
     
@@ -145,8 +150,6 @@ module.exports = function code(options, issue) {
       
       var params = { code: code };
       if (txn.req && txn.req.state) { params.state = txn.req.state; }
-      
-      // TODO: Catch exceptions
       return respond(txn, res, params);
     }
     

--- a/lib/grant/code.js
+++ b/lib/grant/code.js
@@ -132,7 +132,7 @@ module.exports = function code(options, issue) {
     
     if (!respond) {
       // http://lists.openid.net/pipermail/openid-specs-ab/Week-of-Mon-20140317/004680.html
-      return next(new AuthorizationError('Unsupported response mode: ' + mode, undefined, null, 501));
+      return next(new AuthorizationError('Unsupported response mode: ' + mode, 'unsupported_response_mode', null, 501));
     }
     if (respond && respond.validate) {
       try {

--- a/lib/grant/code.js
+++ b/lib/grant/code.js
@@ -64,6 +64,11 @@ module.exports = function code(options, issue) {
   
   if (!issue) { throw new TypeError('oauth2orize.code grant requires an issue callback'); }
   
+  var modes = options.modes || {};
+  if (!modes.query) {
+    modes.query = require('../response/query');
+  }
+  
   // For maximum flexibility, multiple scope spearators can optionally be
   // allowed.  This allows the server to accept clients that separate scope
   // with either space or comma (' ', ',').  This violates the specification,
@@ -118,28 +123,31 @@ module.exports = function code(options, issue) {
    * @api public
    */
   function response(txn, res, next) {
+    var mode = 'query'
+      , respond;
+    if (txn.req && txn.req.responseMode) {
+      mode = txn.req.responseMode;
+    }
+    respond = modes[mode];
+    
     if (!txn.redirectURI) { return next(new Error('Unable to issue redirect for OAuth 2.0 transaction')); }
     if (!txn.res.allow) {
-      var parsed = url.parse(txn.redirectURI, true);
-      delete parsed.search;
-      parsed.query.error = 'access_denied';
-      if (txn.req && txn.req.state) { parsed.query.state = txn.req.state; }
+      var params = { error: 'access_denied' };
+      if (txn.req && txn.req.state) { params.state = txn.req.state; }
       
-      var location = url.format(parsed);
-      return res.redirect(location);
+      // TODO: Catch exceptions
+      return respond(txn, res, params);
     }
     
     function issued(err, code) {
       if (err) { return next(err); }
       if (!code) { return next(new AuthorizationError('Request denied by authorization server', 'access_denied')); }
       
-      var parsed = url.parse(txn.redirectURI, true);
-      delete parsed.search;
-      parsed.query.code = code;
-      if (txn.req && txn.req.state) { parsed.query.state = txn.req.state; }
+      var params = { code: code };
+      if (txn.req && txn.req.state) { params.state = txn.req.state; }
       
-      var location = url.format(parsed);
-      return res.redirect(location);
+      // TODO: Catch exceptions
+      return respond(txn, res, params);
     }
     
     // NOTE: The `redirect_uri`, if present in the client's authorization

--- a/lib/grant/code.js
+++ b/lib/grant/code.js
@@ -130,7 +130,10 @@ module.exports = function code(options, issue) {
     }
     respond = modes[mode];
     
-    if (!respond) { return next(new AuthorizationError('Unsupported response mode: ' + mode, undefined, null, 501)); }
+    if (!respond) {
+      // http://lists.openid.net/pipermail/openid-specs-ab/Week-of-Mon-20140317/004680.html
+      return next(new AuthorizationError('Unsupported response mode: ' + mode, undefined, null, 501));
+    }
     if (respond && respond.validate) {
       try {
         respond.validate(txn);

--- a/lib/grant/token.js
+++ b/lib/grant/token.js
@@ -130,6 +130,10 @@ module.exports = function token(options, issue) {
     }
     respond = modes[mode];
     
+    if (!respond) {
+      // http://lists.openid.net/pipermail/openid-specs-ab/Week-of-Mon-20140317/004680.html
+      return next(new AuthorizationError('Unsupported response mode: ' + mode, undefined, null, 501));
+    }
     if (respond && respond.validate) {
       try {
         respond.validate(txn);

--- a/lib/grant/token.js
+++ b/lib/grant/token.js
@@ -132,7 +132,7 @@ module.exports = function token(options, issue) {
     
     if (!respond) {
       // http://lists.openid.net/pipermail/openid-specs-ab/Week-of-Mon-20140317/004680.html
-      return next(new AuthorizationError('Unsupported response mode: ' + mode, undefined, null, 501));
+      return next(new AuthorizationError('Unsupported response mode: ' + mode, 'unsupported_response_mode', null, 501));
     }
     if (respond && respond.validate) {
       try {

--- a/lib/grant/token.js
+++ b/lib/grant/token.js
@@ -64,6 +64,11 @@ module.exports = function token(options, issue) {
   
   if (!issue) { throw new TypeError('oauth2orize.token grant requires an issue callback'); }
   
+  var modes = options.modes || {};
+  if (!modes.fragment) {
+    modes.fragment = require('../response/fragment');
+  }
+  
   // For maximum flexibility, multiple scope spearators can optionally be
   // allowed.  This allows the server to accept clients that separate scope
   // with either space or comma (' ', ',').  This violates the specification,
@@ -118,17 +123,25 @@ module.exports = function token(options, issue) {
    * @api public
    */
   function response(txn, res, next) {
-    if (!txn.redirectURI) { return next(new Error('Unable to issue redirect for OAuth 2.0 transaction')); }
+    var mode = 'fragment'
+      , respond;
+    if (txn.req && txn.req.responseMode) {
+      mode = txn.req.responseMode;
+    }
+    respond = modes[mode];
+    
+    if (respond && respond.validate) {
+      try {
+        respond.validate(txn);
+      } catch(ex) {
+        return next(ex);
+      }
+    }
+    
     if (!txn.res.allow) {
-      var err = {};
-      err.error = 'access_denied';
-      if (txn.req && txn.req.state) { err.state = txn.req.state; }
-      
-      var parsed = url.parse(txn.redirectURI);
-      parsed.hash = qs.stringify(err);
-      
-      var location = url.format(parsed);
-      return res.redirect(location);
+      var params = { error: 'access_denied' };
+      if (txn.req && txn.req.state) { params.state = txn.req.state; }
+      return respond(txn, res, params);
     }
     
     function issued(err, accessToken, params) {
@@ -140,12 +153,7 @@ module.exports = function token(options, issue) {
       if (params) { utils.merge(tok, params); }
       tok.token_type = tok.token_type || 'Bearer';
       if (txn.req && txn.req.state) { tok.state = txn.req.state; }
-      
-      var parsed = url.parse(txn.redirectURI);
-      parsed.hash = qs.stringify(tok);
-      
-      var location = url.format(parsed);
-      return res.redirect(location);
+      return respond(txn, res, tok);
     }
     
     // NOTE: In contrast to an authorization code grant, redirectURI is not

--- a/lib/middleware/errorHandler.js
+++ b/lib/middleware/errorHandler.js
@@ -90,12 +90,14 @@ module.exports = function(options) {
         if (type.containsAny(fragment)) { enc = 'fragment'; }
         if (req.oauth2.req.responseMode) {
           // Encode the response using the requested mode, if specified.
-          enc = txn.req.responseMode;
+          enc = req.oauth2.req.responseMode;
         }
       }
 
       var respond = modes[enc]
         , params = {};
+
+      if (!respond) { return next(err); }
 
       params.error = err.code || 'server_error';
       if (err.message) { params.error_description = err.message; }

--- a/lib/middleware/errorHandler.js
+++ b/lib/middleware/errorHandler.js
@@ -47,7 +47,15 @@ module.exports = function(options) {
   options = options || {};
   
   var mode = options.mode || 'direct'
-    , fragment = options.fragment || ['token'];
+    , fragment = options.fragment || ['token']
+    , modes = options.modes || {};
+  
+  if (!modes.query) {
+    modes.query = require('../response/query');
+  }
+  if (!modes.fragment) {
+    modes.fragment = require('../response/fragment');
+  }
   
   return function errorHandler(err, req, res, next) {
     if (mode == 'direct') {
@@ -80,28 +88,20 @@ module.exports = function(options) {
         // if the response type contains any value that requires fragment
         // encoding, the response will be fragment encoded.
         if (type.containsAny(fragment)) { enc = 'fragment'; }
+        if (req.oauth2.req.responseMode) {
+          // Encode the response using the requested mode, if specified.
+          enc = txn.req.responseMode;
+        }
       }
 
-      var redirectURI = req.oauth2.redirectURI
-        , uri = url.parse(redirectURI, true);
+      var respond = modes[enc]
+        , params = {};
 
-      if (enc == 'fragment') {
-        var hash = {};
-        hash.error = err.code || 'server_error';
-        if (err.message) { hash.error_description = err.message; }
-        if (err.uri) { hash.error_uri = err.uri; }
-        if (req.oauth2.req && req.oauth2.req.state) { hash.state = req.oauth2.req.state; }
-        uri.hash = qs.stringify(hash);
-      } else {
-        delete uri.search;
-        uri.query.error = err.code || 'server_error';
-        if (err.message) { uri.query.error_description = err.message; }
-        if (err.uri) { uri.query.error_uri = err.uri; }
-        if (req.oauth2.req && req.oauth2.req.state) { uri.query.state = req.oauth2.req.state; }
-      }
-
-      var location = url.format(uri);
-      res.redirect(location);
+      params.error = err.code || 'server_error';
+      if (err.message) { params.error_description = err.message; }
+      if (err.uri) { params.error_uri = err.uri; }
+      if (req.oauth2.req && req.oauth2.req.state) { params.state = req.oauth2.req.state; }
+      return respond(req.oauth2, res, params);
     } else {
       return next(err);
     }

--- a/lib/response/fragment.js
+++ b/lib/response/fragment.js
@@ -5,10 +5,15 @@ var url = require('url')
 * Authorization Response parameters are encoded in the fragment added to the redirect_uri when 
 * redirecting back to the Client.
 **/
-module.exports = function (txn, res, params) {
+exports = module.exports = function (txn, res, params) {
   var parsed = url.parse(txn.redirectURI);
   parsed.hash = qs.stringify(params || {});
 
   var location = url.format(parsed);
   return res.redirect(location);
+};
+
+
+exports.validate = function(txn) {
+  if (!txn.redirectURI) { throw new Error('Unable to issue redirect for OAuth 2.0 transaction'); }
 };

--- a/lib/response/fragment.js
+++ b/lib/response/fragment.js
@@ -1,0 +1,14 @@
+var url = require('url')
+  , qs = require('querystring');
+
+/**
+* Authorization Response parameters are encoded in the fragment added to the redirect_uri when 
+* redirecting back to the Client.
+**/
+module.exports = function (txn, res, params) {
+  var parsed = url.parse(txn.redirectURI);
+  parsed.hash = qs.stringify(params || {});
+
+  var location = url.format(parsed);
+  return res.redirect(location);
+};

--- a/lib/response/fragment.js
+++ b/lib/response/fragment.js
@@ -7,7 +7,7 @@ var url = require('url')
 **/
 exports = module.exports = function (txn, res, params) {
   var parsed = url.parse(txn.redirectURI);
-  parsed.hash = qs.stringify(params || {});
+  parsed.hash = qs.stringify(params);
 
   var location = url.format(parsed);
   return res.redirect(location);

--- a/lib/response/query.js
+++ b/lib/response/query.js
@@ -4,7 +4,7 @@ var url = require('url');
 * Authorization Response parameters are encoded in the query string added to the redirect_uri when 
 * redirecting back to the Client.
 **/
-module.exports = function (txn, res, params) {
+exports = module.exports = function (txn, res, params) {
   var parsed = url.parse(txn.redirectURI, true);
   delete parsed.search;
   Object.keys(params).forEach(function (k) {
@@ -13,4 +13,8 @@ module.exports = function (txn, res, params) {
 
   var location = url.format(parsed);
   return res.redirect(location);
+};
+
+exports.validate = function(txn) {
+  if (!txn.redirectURI) { throw new Error('Unable to issue redirect for OAuth 2.0 transaction'); }
 };

--- a/lib/response/query.js
+++ b/lib/response/query.js
@@ -1,0 +1,16 @@
+var url = require('url');
+
+/**
+* Authorization Response parameters are encoded in the query string added to the redirect_uri when 
+* redirecting back to the Client.
+**/
+module.exports = function (txn, res, params) {
+  var parsed = url.parse(txn.redirectURI, true);
+  delete parsed.search;
+  Object.keys(params || {}).forEach(function (k) {
+    parsed.query[k] = params[k];
+  });
+
+  var location = url.format(parsed);
+  return res.redirect(location);
+};

--- a/lib/response/query.js
+++ b/lib/response/query.js
@@ -7,7 +7,7 @@ var url = require('url');
 module.exports = function (txn, res, params) {
   var parsed = url.parse(txn.redirectURI, true);
   delete parsed.search;
-  Object.keys(params || {}).forEach(function (k) {
+  Object.keys(params).forEach(function (k) {
     parsed.query[k] = params[k];
   });
 

--- a/test/grant/code.test.js
+++ b/test/grant/code.test.js
@@ -677,6 +677,39 @@ describe('grant.code', function() {
         expect(response.getHeader('Location')).to.equal('/foo');
       });
     });
+    
+    describe('transaction using unsupported response mode', function() {
+      var err;
+      
+      before(function(done) {
+        chai.oauth2orize.grant(code({ modes: { foo: fooResponseMode } }, issue))
+          .txn(function(txn) {
+            txn.client = { id: 'c123', name: 'Example' };
+            txn.redirectURI = 'http://www.example.com/auth/callback';
+            txn.req = {
+              redirectURI: 'http://example.com/auth/callback',
+              state: 's1t2u3',
+              responseMode: 'fubar'
+            };
+            txn.user = { id: 'u123', name: 'Bob' };
+            txn.res = { allow: true };
+          })
+          .next(function(e) {
+            err = e;
+            done();
+          })
+          .decide();
+      });
+      
+      it('should error', function() {
+        expect(err).to.be.an.instanceOf(Error);
+        expect(err.constructor.name).to.equal('AuthorizationError');
+        expect(err.message).to.equal('Unsupported response mode: fubar');
+        expect(err.code).to.equal('server_error');
+        expect(err.uri).to.equal(null);
+        expect(err.status).to.equal(501);
+      });
+    });
   });
   
 });

--- a/test/grant/code.test.js
+++ b/test/grant/code.test.js
@@ -705,7 +705,7 @@ describe('grant.code', function() {
         expect(err).to.be.an.instanceOf(Error);
         expect(err.constructor.name).to.equal('AuthorizationError');
         expect(err.message).to.equal('Unsupported response mode: fubar');
-        expect(err.code).to.equal('server_error');
+        expect(err.code).to.equal('unsupported_response_mode');
         expect(err.uri).to.equal(null);
         expect(err.status).to.equal(501);
       });

--- a/test/grant/token.test.js
+++ b/test/grant/token.test.js
@@ -587,5 +587,118 @@ describe('grant.token', function() {
       });
     });
   });
+  
+  describe('decision handling with response mode', function() {
+    function issue(client, user, done) {
+      if (client.id == 'c123' && user.id == 'u123') {
+        return done(null, 'xyz');
+      }
+      return done(new Error('something is wrong'));
+    }
+    
+    var fooResponseMode = function(txn, res, params) {
+      expect(txn.req.redirectURI).to.equal('http://example.com/auth/callback');
+      expect(params.access_token).to.equal('xyz');
+      expect(params.token_type).to.equal('Bearer');
+      expect(params.state).to.equal('s1t2u3');
+      
+      res.redirect('/foo');
+    }
+    
+    
+    describe('transaction using default response mode', function() {
+      var response;
+      
+      before(function(done) {
+        chai.oauth2orize.grant(token({ modes: { foo: fooResponseMode } }, issue))
+          .txn(function(txn) {
+            txn.client = { id: 'c123', name: 'Example' };
+            txn.redirectURI = 'http://example.com/auth/callback';
+            txn.req = {
+              redirectURI: 'http://example.com/auth/callback',
+              state: 's1t2u3'
+            };
+            txn.user = { id: 'u123', name: 'Bob' };
+            txn.res = { allow: true };
+          })
+          .end(function(res) {
+            response = res;
+            done();
+          })
+          .decide();
+      });
+      
+      it('should respond', function() {
+        expect(response.statusCode).to.equal(302);
+        expect(response.getHeader('Location')).to.equal('http://example.com/auth/callback#access_token=xyz&token_type=Bearer&state=s1t2u3');
+      });
+    });
+    
+    describe('transaction using foo response mode', function() {
+      var response;
+      
+      before(function(done) {
+        chai.oauth2orize.grant(token({ modes: { foo: fooResponseMode } }, issue))
+          .txn(function(txn) {
+            txn.client = { id: 'c123', name: 'Example' };
+            txn.redirectURI = 'http://example.com/auth/callback';
+            txn.req = {
+              redirectURI: 'http://example.com/auth/callback',
+              state: 's1t2u3',
+              responseMode: 'foo'
+            };
+            txn.user = { id: 'u123', name: 'Bob' };
+            txn.res = { allow: true };
+          })
+          .end(function(res) {
+            response = res;
+            done();
+          })
+          .decide();
+      });
+      
+      it('should respond', function() {
+        expect(response.statusCode).to.equal(302);
+        expect(response.getHeader('Location')).to.equal('/foo');
+      });
+    });
+    
+    describe('disallowed transaction using foo response mode', function() {
+      var fooResponseMode = function(txn, res, params) {
+        expect(txn.req.redirectURI).to.equal('http://example.com/auth/callback');
+        expect(params.error).to.equal('access_denied');
+        expect(params.state).to.equal('s1t2u3');
+      
+        res.redirect('/foo');
+      }
+      
+      var response;
+      
+      before(function(done) {
+        chai.oauth2orize.grant(token({ modes: { foo: fooResponseMode } }, issue))
+          .txn(function(txn) {
+            txn.client = { id: 'c123', name: 'Example' };
+            txn.redirectURI = 'http://example.com/auth/callback';
+            txn.req = {
+              redirectURI: 'http://example.com/auth/callback',
+              state: 's1t2u3',
+              responseMode: 'foo'
+            };
+            txn.user = { id: 'u123', name: 'Bob' };
+            txn.res = { allow: false };
+          })
+          .end(function(res) {
+            response = res;
+            done();
+          })
+          .decide();
+      });
+      
+      it('should respond', function() {
+        expect(response.statusCode).to.equal(302);
+        expect(response.getHeader('Location')).to.equal('/foo');
+      });
+    });
+  });
 
 });

--- a/test/grant/token.test.js
+++ b/test/grant/token.test.js
@@ -727,7 +727,7 @@ describe('grant.token', function() {
         expect(err).to.be.an.instanceOf(Error);
         expect(err.constructor.name).to.equal('AuthorizationError');
         expect(err.message).to.equal('Unsupported response mode: fubar');
-        expect(err.code).to.equal('server_error');
+        expect(err.code).to.equal('unsupported_response_mode');
         expect(err.uri).to.equal(null);
         expect(err.status).to.equal(501);
       });


### PR DESCRIPTION
This is an alternative implementation of #105, which fixes some security issues and makes response_mode support more extensible.

See also:
https://github.com/jaredhanson/oauth2orize-response-mode
https://github.com/jaredhanson/oauth2orize-fprm