### PR TITLE
Add handleAllErrors flag to errorHandler's options

### DIFF
--- a/lib/middleware/errorHandler.js
+++ b/lib/middleware/errorHandler.js
@@ -20,7 +20,12 @@ var url = require('url')
  * to the client indirectly via a redirect through the user's browser.
  *
  * Options:
- *   - `mode`   mode of operation, defaults to `direct`
+ *   - `mode`               mode of operation, defaults to `direct`
+ *   - `handleAllErrors`    if true, will set HTTP status to 500 on unexpeted errors,
+ *                          if false, will call next(err) instead. Defaults to `true`
+ *                          and is only relevant in `direct` mode. You'd want to set
+ *                          it to false if you're implementing your own error handler
+ *                          which handles internal errors.
  *
  * Examples:
  *
@@ -47,6 +52,7 @@ module.exports = function(options) {
   options = options || {};
   
   var mode = options.mode || 'direct'
+    , handleAllErrors = options.handleAllErrors === undefined ? true : options.handleAllErrors
     , fragment = options.fragment || ['token']
     , modes = options.modes || {};
   
@@ -60,7 +66,10 @@ module.exports = function(options) {
   return function errorHandler(err, req, res, next) {
     if (mode == 'direct') {
       if (err.status) { res.statusCode = err.status; }
-      if (!res.statusCode || res.statusCode < 400) { res.statusCode = 500; }
+      if (!res.statusCode || res.statusCode < 400) {
+        if (!handleAllErrors) return next(err);
+        res.statusCode = 500;
+      }
       
       if (res.statusCode == 401) {
         // TODO: set WWW-Authenticate header


### PR DESCRIPTION
The errorHandler middleware "swallows" unknown errors in direct mode by setting the status code to 500 and sending the response. This makes it impossible for a user to implement his own global error handler, for example to print the stack traces of all uncaught errors (think about errors with the database).

This change adds `handleAllErrors` options flag with the default value `true`:

- When set to `true`, errorHandler will behave as before
- When set to `false`, errorHandler will call `next(err)` for unknown
  errors and thus propagate the error to the global error handler

Thanks.