### PR TITLE
token should not fail when scope is an array instance

### DIFF
--- a/lib/grant/token.js
+++ b/lib/grant/token.js
@@ -93,7 +93,7 @@ module.exports = function token(options, issue) {
       
     if (!clientID) { throw new AuthorizationError('Missing required parameter: client_id', 'invalid_request'); }
     
-    if (scope) {
+    if (scope && !Array.isArray(scope)) {
       for (var i = 0, len = separators.length; i < len; i++) {
         var separated = scope.split(separators[i]);
         // only separate on the first matching separator.  this allows for a sort

--- a/test/grant/token.test.js
+++ b/test/grant/token.test.js
@@ -234,6 +234,42 @@ describe('grant.token', function() {
       });
     });
     
+
+    describe('request with an array of scopes', function() {
+      var err, out;
+
+      before(function(done) {
+        chai.oauth2orize.grant(token(issue))
+          .req(function(req) {
+            req.query = {};
+            req.query.client_id = 'c123';
+            req.query.redirect_uri = 'http://example.com/auth/callback';
+            req.query.scope = [ 'read',  'write'];
+            req.query.state = 'f1o1o1';
+          })
+          .parse(function(e, o) {
+            err = e;
+            out = o;
+            done();
+          })
+          .authorize();
+      });
+
+      it('should not error', function() {
+        expect(err).to.be.null;
+      });
+
+      it('should parse request', function() {
+        expect(out.clientID).to.equal('c123');
+        expect(out.redirectURI).to.equal('http://example.com/auth/callback');
+        expect(out.scope).to.be.an('array');
+        expect(out.scope).to.have.length(2);
+        expect(out.scope[0]).to.equal('read');
+        expect(out.scope[1]).to.equal('write');
+        expect(out.state).to.equal('f1o1o1');
+      });
+    });
+
     describe('request with missing client_id parameter', function() {
       var err, out;
       


### PR DESCRIPTION
Hello Jared,
This PR was made to solve an issue when a client sends multiple scopes.
There is a client that is invoking our `/authorize` endpoint sending multiple scopes  with the following syntax `https://...?...&scope=openid&scope=email`
That `qs` is being parsed by our middleware and then the middleware sets the following array to the scope property.
```
req.query.scope = [ 'openid', ' email' ]
```

An array as scope's value breaks your code with the following error:
```
TypeError: scope.split is not a function
    at Object.request [as handle] (/usr/local/lib/.../node_modules/oauth2orize/lib/grant/token.js:98:31)
    ...
``` 
Hope you agree with this fix.
Thanks, Silvio