### PR TITLE
Also allow email as a request parameter

### DIFF
--- a/lib/exchange/password.js
+++ b/lib/exchange/password.js
@@ -82,11 +82,11 @@ module.exports = function(options, issue) {
     // The 'user' property of `req` holds the authenticated user.  In the case
     // of the token endpoint, the property will contain the OAuth 2.0 client.
     var client = req[userProperty]
-      , username = req.body.username
+      , username = req.body.username || req.body.email
       , passwd = req.body.password
       , scope = req.body.scope;
       
-    if (!username) { return next(new TokenError('Missing required parameter: username', 'invalid_request')); }
+    if (!username) { return next(new TokenError('Missing required parameter: username/email', 'invalid_request')); }
     if (!passwd) { return next(new TokenError('Missing required parameter: password', 'invalid_request')); }
     
     if (scope) {

--- a/test/exchange/password.test.js
+++ b/test/exchange/password.test.js
@@ -318,7 +318,7 @@ describe('exchange.password', function() {
     it('should error', function() {
       expect(err).to.be.an.instanceOf(Error);
       expect(err.constructor.name).to.equal('TokenError');
-      expect(err.message).to.equal('Missing required parameter: username');
+      expect(err.message).to.equal('Missing required parameter: username/email');
       expect(err.code).to.equal('invalid_request');
       expect(err.status).to.equal(400);
     });


### PR DESCRIPTION
I have usernames in a project that are not unique by design, so email becomes the unique identifier. It gets very confusing to authenticate with email when the request expects username as a paramater.