### PR TITLE
support to specify the grant type from the query string

### DIFF
--- a/lib/middleware/token.js
+++ b/lib/middleware/token.js
@@ -51,7 +51,7 @@ module.exports = function token(server, options) {
   if (!server) { throw new TypeError('oauth2orize.token middleware requires a server argument'); }
   
   return function token(req, res, next) {
-    var type = req.body.grant_type;
+    var type = req.body.grant_type || req.query.grant_type;
     
     server._exchange(type, req, res, function(err) {
       if (err) { return next(err); }


### PR DESCRIPTION
most implementations support parsing the `grant_type` from the url