### PR TITLE
password grant: check scope type before split

### DIFF
--- a/lib/exchange/password.js
+++ b/lib/exchange/password.js
@@ -90,6 +90,7 @@ module.exports = function(options, issue) {
     if (!passwd) { return next(new TokenError('Missing required parameter: password', 'invalid_request')); }
     
     if (scope) {
+      if (typeof scope !== 'string') { return next(new TokenError('Invalid scope parameter, scope must be a string', 'invalid_request'));  }
       for (var i = 0, len = separators.length; i < len; i++) {
         var separated = scope.split(separators[i]);
         // only separate on the first matching separator.  this allows for a sort


### PR DESCRIPTION
got error if scope send as array

```
$ curl -s -X POST http://localhost:8003/oauth/token -d '{"grant_type": "password", "username": "test@test.net", "password": "123123123", "scope": [1,2,3],  "client_id": "test", "client_secret": "test"}' | jq '.'
{
  "error": "server_error",
  "error_description": "scope.split is not a function"
}
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jaredhanson/oauth2orize/170)
<!-- Reviewable:end -->
