### PR TITLE
add "req.authInfo" to the clientCredentials exchange

### DIFF
--- a/lib/exchange/clientCredentials.js
+++ b/lib/exchange/clientCredentials.js
@@ -16,7 +16,7 @@ var utils = require('../utils')
  * This middleware requires an `issue` callback, for which the function
  * signature is as follows:
  *
- *     function(client, scope, done) { ... }
+ *     function(client, scope, body, authInfo, done) { ... }
  *
  * `client` is the authenticated client instance attempting to obtain an access
  * token.  `scope` is the scope of access requested by the client.  `done` is
@@ -119,7 +119,9 @@ module.exports = function(options, issue) {
     
     try {
       var arity = issue.length;
-      if (arity == 4) {
+      if (arity == 5) {
+        issue(client, scope, req.body, req.authInfo, issued);
+      } else if (arity == 4) {
         issue(client, scope, req.body, issued);
       } else if (arity == 3) {
         issue(client, scope, issued);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oauth2orize",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "OAuth 2.0 authorization server toolkit for Node.js.",
   "keywords": [
     "oauth",


### PR DESCRIPTION
This is the same scenario that the pull request #167:

This could be used to set other auth params like req.ip, clientAuthenticated, etc.

In this case, it was applied to client credentials but the behaviour is the same.
