### PR TITLE
req.query.client_id must be string

### DIFF
--- a/lib/grant/code.js
+++ b/lib/grant/code.js
@@ -92,6 +92,7 @@ module.exports = function code(options, issue) {
       , state = req.query.state;
       
     if (!clientID) { throw new AuthorizationError('Missing required parameter: client_id', 'invalid_request'); }
+    if (typeof clientID !== 'string') { throw new AuthorizationError('Invalid parameter: client_id must be a string', 'invalid_request'); }
     
     if (scope) {
       if (typeof scope !== 'string') {

--- a/lib/grant/token.js
+++ b/lib/grant/token.js
@@ -92,6 +92,7 @@ module.exports = function token(options, issue) {
       , state = req.query.state;
       
     if (!clientID) { throw new AuthorizationError('Missing required parameter: client_id', 'invalid_request'); }
+    if (typeof clientID !== 'string') { throw new AuthorizationError('Invalid parameter: client_id must be a string', 'invalid_request'); }
     
     if (scope) {
       if (typeof scope !== 'string') {

--- a/test/grant/code.test.js
+++ b/test/grant/code.test.js
@@ -261,6 +261,33 @@ describe('grant.code', function() {
       });
     });
 
+    describe('request with invalid client_id parameter', function() {
+      var err, out;
+      
+      before(function(done) {
+        chai.oauth2orize.grant(code(issue))
+          .req(function(req) {
+            req.query = {};
+            req.query.client_id = ['c123', 'c123'];
+            req.query.redirect_uri = 'http://example.com/auth/callback';
+            req.query.state = 'f1o1o1';
+          })
+          .parse(function(e, o) {
+            err = e;
+            out = o;
+            done();
+          })
+          .authorize();
+      });
+      
+      it('should error', function() {
+        expect(err).to.be.an.instanceOf(Error);
+        expect(err.constructor.name).to.equal('AuthorizationError');
+        expect(err.message).to.equal('Invalid parameter: client_id must be a string');
+        expect(err.code).to.equal('invalid_request');
+      });
+    });
+
    describe('request with scope parameter that is not a string', function() {
       var err, out;
       

--- a/test/grant/token.test.js
+++ b/test/grant/token.test.js
@@ -261,6 +261,33 @@ describe('grant.token', function() {
       });
     });
 
+    describe('request with invalid client_id parameter', function() {
+      var err, out;
+      
+      before(function(done) {
+        chai.oauth2orize.grant(token(issue))
+          .req(function(req) {
+            req.query = {};
+            req.query.client_id = ['c123', 'c123'];
+            req.query.redirect_uri = 'http://example.com/auth/callback';
+            req.query.state = 'f1o1o1';
+          })
+          .parse(function(e, o) {
+            err = e;
+            out = o;
+            done();
+          })
+          .authorize();
+      });
+      
+      it('should error', function() {
+        expect(err).to.be.an.instanceOf(Error);
+        expect(err.constructor.name).to.equal('AuthorizationError');
+        expect(err.message).to.equal('Invalid parameter: client_id must be a string');
+        expect(err.code).to.equal('invalid_request');
+      });
+    });
+
    describe('request with scope parameter that is not a string', function() {
       var err, out;
       


### PR DESCRIPTION
for example, when `&client_id` was specified twice, `req.query.client_id` is an array
