### PR TITLE
Allow postAllow hook function to run between allow decision and response.

### DIFF
--- a/lib/middleware/authorization.js
+++ b/lib/middleware/authorization.js
@@ -137,6 +137,15 @@ module.exports = function(server, options, validate, immediate) {
         function immediated(err, allow, info, locals) {
           if (err) { return next(err); }
           if (allow) {
+            function proceed(err) {
+              if (err) { return next(err); }
+
+              server._respond(req.oauth2, res, function(err) {
+                if (err) { return next(err); }
+                return next(new AuthorizationError('Unsupported response type: ' + req.oauth2.req.type, 'unsupported_response_type'));
+              });
+            }
+
             req.oauth2.res = info || {};
             req.oauth2.res.allow = true;
             if (locals) {
@@ -144,10 +153,11 @@ module.exports = function(server, options, validate, immediate) {
               utils.merge(req.oauth2.locals, locals);
             }
 
-            server._respond(req.oauth2, res, function(err) {
-              if (err) { return next(err); }
-              return next(new AuthorizationError('Unsupported response type: ' + req.oauth2.req.type, 'unsupported_response_type'));
-            });
+            if (options.postAllow) {
+              return options.postAllow(req, res, req.oauth2, proceed);
+            }
+
+            proceed(null);
           } else {
             // Add info and locals to `req.oauth2`, where they will be
             // available to the next middleware.  Since this is a

--- a/lib/middleware/resume.js
+++ b/lib/middleware/resume.js
@@ -29,29 +29,39 @@ module.exports = function(server, options, immediate) {
     function immediated(err, allow, info, locals) {
       if (err) { return next(err); }
       if (allow) {
+        function proceed (err) {
+          if (err) { return next(err); }
+
+          server._respond(req.oauth2, res, function(err) {
+            if (err) { return next(err); }
+            return next(new AuthorizationError('Unsupported response type: ' + req.oauth2.req.type, 'unsupported_response_type'));
+          });
+        }
+
         req.oauth2.res = info || {};
         req.oauth2.res.allow = true;
         if (locals) {
           req.oauth2.locals = req.oauth2.locals || {};
           utils.merge(req.oauth2.locals, locals);
         }
-        
+
         // proxy end() to delete the transaction
         var end = res.end;
         res.end = function(chunk, encoding) {
           if (server._txnStore.legacy == true) {
             server._txnStore.remove(options, req, req.oauth2.transactionID, function noop(){});
           }
-    
+
           res.end = end;
           res.end(chunk, encoding);
         };
         req.oauth2._endProxied = true;
 
-        server._respond(req.oauth2, res, function(err) {
-          if (err) { return next(err); }
-          return next(new AuthorizationError('Unsupported response type: ' + req.oauth2.req.type, 'unsupported_response_type'));
-        });
+        if (options.postAllow) {
+          return options.postAllow(req, res, req.oauth2, proceed);
+        }
+
+        proceed(null);
       } else {
         req.oauth2.info = info;
         if (locals) {


### PR DESCRIPTION
This PR adds the capability to hand through an option an arbitrary function with definition `function (req, res, txn, cb)` to `server.authorization` and `server.resume` to be run after an `allow: true` decision is made by `immediateResponse`.