### PR TITLE
exchanges: add scope type validation

### DIFF
--- a/lib/exchange/clientCredentials.js
+++ b/lib/exchange/clientCredentials.js
@@ -84,6 +84,10 @@ module.exports = function(options, issue) {
       , scope = req.body.scope;
     
     if (scope) {
+      if (typeof scope !== 'string') {
+        return next(new TokenError('Invalid parameter: scope must be a string', 'invalid_scope'));
+      }
+
       for (var i = 0, len = separators.length; i < len; i++) {
         var separated = scope.split(separators[i]);
         // only separate on the first matching separator.  this allows for a sort

--- a/lib/exchange/password.js
+++ b/lib/exchange/password.js
@@ -90,6 +90,10 @@ module.exports = function(options, issue) {
     if (!passwd) { return next(new TokenError('Missing required parameter: password', 'invalid_request')); }
     
     if (scope) {
+      if (typeof scope !== 'string') {
+        return next(new TokenError('Invalid parameter: scope must be a string', 'invalid_scope'));
+      }
+
       for (var i = 0, len = separators.length; i < len; i++) {
         var separated = scope.split(separators[i]);
         // only separate on the first matching separator.  this allows for a sort

--- a/lib/exchange/refreshToken.js
+++ b/lib/exchange/refreshToken.js
@@ -85,6 +85,10 @@ module.exports = function(options, issue) {
     if (!refreshToken) { return next(new TokenError('Missing required parameter: refresh_token', 'invalid_request')); }
     
     if (scope) {
+      if (typeof scope !== 'string') {
+        return next(new TokenError('Invalid parameter: scope must be a string', 'invalid_scope'));
+      }
+
       for (var i = 0, len = separators.length; i < len; i++) {
         var separated = scope.split(separators[i]);
         // only separate on the first matching separator.  this allows for a sort

--- a/lib/grant/code.js
+++ b/lib/grant/code.js
@@ -96,7 +96,7 @@ module.exports = function code(options, issue) {
     
     if (scope) {
       if (typeof scope !== 'string') {
-        throw new AuthorizationError('Invalid parameter: scope must be a string', 'invalid_request');
+        throw new AuthorizationError('Invalid parameter: scope must be a string', 'invalid_scope');
       }
 
       for (var i = 0, len = separators.length; i < len; i++) {

--- a/lib/grant/token.js
+++ b/lib/grant/token.js
@@ -96,7 +96,7 @@ module.exports = function token(options, issue) {
     
     if (scope) {
       if (typeof scope !== 'string') {
-        throw new AuthorizationError('Invalid parameter: scope must be a string', 'invalid_request');
+        throw new AuthorizationError('Invalid parameter: scope must be a string', 'invalid_scope');
       }
 
       for (var i = 0, len = separators.length; i < len; i++) {

--- a/test/exchange/clientCredentials.test.js
+++ b/test/exchange/clientCredentials.test.js
@@ -429,6 +429,35 @@ describe('exchange.clientCredentials', function() {
       expect(err.message).to.equal('OAuth2orize requires body parsing. Did you forget app.use(express.bodyParser())?');
     });
   });
+
+  describe('handling a request where scope format is not string', function () {
+    var response, err;
+
+    before(function (done) {
+      function issue(client, done) {
+        return done(null, '.ignore')
+      }
+
+      chai.connect.use(clientCredentials(issue))
+        .req(function (req) {
+          req.user = { id: 'c123', name: 'Example' };
+          req.body = { scope: ['read', 'write'] };
+        })
+        .next(function (e) {
+          err = e;
+          done();
+        })
+        .dispatch();
+    });
+
+    it('should error', function () {
+      expect(err).to.be.an.instanceOf(Error);
+      expect(err.name).to.equal('TokenError');
+      expect(err.message).to.equal('Invalid parameter: scope must be a string');
+      expect(err.code).to.equal('invalid_scope');
+      expect(err.status).to.equal(400);
+    });
+  });  
   
   describe('with scope separator option', function() {
     function issue(client, scope, done) {

--- a/test/exchange/refreshToken.test.js
+++ b/test/exchange/refreshToken.test.js
@@ -467,6 +467,35 @@ describe('exchange.refreshToken', function() {
       expect(err.message).to.equal('OAuth2orize requires body parsing. Did you forget app.use(express.bodyParser())?');
     });
   });
+
+  describe('handling a request where scope format is not string', function () {
+    var response, err;
+
+    before(function (done) {
+      function issue(client, refreshToken, done) {
+        return done(null, '.ignore')
+      }
+
+      chai.connect.use(refreshToken(issue))
+        .req(function (req) {
+          req.user = { id: 'c123', name: 'Example' };
+          req.body = { refresh_token: 'refreshing', scope: ['read', 'write'] };
+        })
+        .next(function (e) {
+          err = e;
+          done();
+        })
+        .dispatch();
+    });
+
+    it('should error', function () {
+      expect(err).to.be.an.instanceOf(Error);
+      expect(err.name).to.equal('TokenError');
+      expect(err.message).to.equal('Invalid parameter: scope must be a string');
+      expect(err.code).to.equal('invalid_scope');
+      expect(err.status).to.equal(400);
+    });
+  });  
   
   describe('with scope separator option', function() {
     describe('issuing an access token based on array of scopes', function() {

--- a/test/grant/code.test.js
+++ b/test/grant/code.test.js
@@ -312,7 +312,7 @@ describe('grant.code', function() {
         expect(err).to.be.an.instanceOf(Error);
         expect(err.constructor.name).to.equal('AuthorizationError');
         expect(err.message).to.equal('Invalid parameter: scope must be a string');
-        expect(err.code).to.equal('invalid_request');
+        expect(err.code).to.equal('invalid_scope');
       });
     });
   });

--- a/test/grant/token.test.js
+++ b/test/grant/token.test.js
@@ -312,7 +312,7 @@ describe('grant.token', function() {
         expect(err).to.be.an.instanceOf(Error);
         expect(err.constructor.name).to.equal('AuthorizationError');
         expect(err.message).to.equal('Invalid parameter: scope must be a string');
-        expect(err.code).to.equal('invalid_request');
+        expect(err.code).to.equal('invalid_scope');
       });
     });
   });


### PR DESCRIPTION
It assures `scope` parameter is a string before we start manipulating it, otherwise you find this type error: `scope.split is not a function`

There is older PR about this: https://github.com/jaredhanson/oauth2orize/pull/170 (but mine solves this for all exchanges + testing)

Notes: 
- I used `invalid_scope` instead of `invalid_request` since by spec:
  > The requested scope is invalid, unknown, or malformed.

  I guess wrong format can be in the `malformed` aspect, however, the library already does this check in [code grant](https://github.com/jaredhanson/oauth2orize/blob/master/lib/grant/code.js#L99) and it returns `invalid_request`. I've added another commit in this PR to "fix" that and to unify them to `invalid_scope`, let me know if you prefer the other way around: all of them returning `invalid_request`.

- The code is repeated in all exchanges, not sure if you have in mind some refactor before or after this PR, let me know if you prefer another validation approach.