### PR TITLE
Add support for custom transaction loaders.

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -138,10 +138,17 @@ Server.prototype.authorization = function(options, validate, immediate, complete
 };
 
 Server.prototype.resume = function(options, immediate, complete) {
+  var ld = transactionLoader;
+  
   if (options && options.loadTransaction === false) {
     return resume(this, options, immediate, complete);
   }
-  return [transactionLoader(this, options), resume(this, options, immediate, complete)];
+  
+  if (options && typeof options.loadTransaction === 'function') {
+    ld = options.loadTransaction;
+  }
+  
+  return [ld(this, options), resume(this, options, immediate, complete)];
 };
 
 /**

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -89,6 +89,18 @@ describe('Server', function() {
       expect(handler).to.be.an('function');
       expect(handler).to.have.length(3);
     });
+    
+    it('should employ custom transaction loader', function() {
+      function customLoader(server, options) { return function customTransaction(req, res, next) {}; };
+      var handler = server.resume({ loadTransaction: customLoader }, function(){});
+      expect(handler).to.be.an('array');
+      expect(handler).to.have.length(2);
+      expect(handler[0]).to.be.a('function');
+      expect(handler[0].name).to.equal('customTransaction');
+      expect(handler[0]).to.have.length(3);
+      expect(handler[1]).to.be.a('function');
+      expect(handler[1]).to.have.length(3);
+    });
   });
   
   describe('#decision', function() {


### PR DESCRIPTION
The `transactionLoader` middleware constructs the `req.oauth2` object on which `oauth2orize` operates during processing of an authorization request. It does so by appealing to a transaction storage callback, which can be used to dynamically load the state to be placed into the `req.oauth2` object.

Although this is generally quite robust, it has an issue in that only a single transaction loader callback may be configured. Particularly for some of the extensions onto the OAuth 2.0 specification (such as the device code flow), transaction loading may be sufficiently different that it is tricky for the restricted callback to properly handle all cases. Although some changes could be made to allow e.g., multiple callback handlers or more extensive function definitions, these changes would introduce complexity and not completely alleviate the issue. Therefore, this PR allows the user to overwrite the entire `transactionLoader` with one of their own design, to either enhance the callback function definition, or provide multiple methods of loading the transaction within the same server. This way we don't change the API for users who want the most simple of implementations, but allow complete power to changes the transaction loading model if necessary or desired. 