### PR TITLE
Fix error in grant code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,10 @@ A client must obtain permission from a user before it is issued an access token.
 This permission is known as a grant, the most common type of which is an
 authorization code.
 ```javascript
-server.grant(oauth2orize.grant.code(function(client, redirectURI, user, ares, done) {
+server.grant(oauth2orize.grant.code(function(client, redirectURI, user, ares, areq, done) {
   var code = utils.uid(16);
 
-  var ac = new AuthorizationCode(code, client.id, redirectURI, user.id, ares.scope);
+  var ac = new AuthorizationCode(code, client.id, redirectURI, user.id, areq.scope);
   ac.save(function(err) {
     if (err) { return done(err); }
     return done(null, code);


### PR DESCRIPTION
This PR updates the code sample of README.md regarding granting code. The scope is available only in the areq object, not the ares.

Here's the return object of the request function, which includes the scope: https://github.com/jaredhanson/oauth2orize/blob/master/lib/grant/code.js#L115