### PR TITLE
require exchange and grants directly

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -32,34 +32,26 @@ exports.createServer = createServer;
 exports.errorHandler = require('./middleware/errorHandler');
 
 /**
- * Auto-load bundled grants.
+ * load grants.
  */
 exports.grant = {};
- 
-fs.readdirSync(__dirname + '/grant').forEach(function(filename) {
-  if (/\.js$/.test(filename)) {
-    var name = path.basename(filename, '.js');
-    var load = function () { return require('./grant/' + name); };
-    exports.grant.__defineGetter__(name, load);
-  }
-});
+exports.grant.code = require('./grant/code');
+exports.grant.token =  require('./grant/token');
+
 
 // alias grants
 exports.grant.authorizationCode = exports.grant.code;
 exports.grant.implicit = exports.grant.token;
 
 /**
- * Auto-load bundled exchanges.
+ * load exchanges.
  */
 exports.exchange = {};
- 
-fs.readdirSync(__dirname + '/exchange').forEach(function(filename) {
-  if (/\.js$/.test(filename)) {
-    var name = path.basename(filename, '.js');
-    var load = function () { return require('./exchange/' + name); };
-    exports.exchange.__defineGetter__(name, load);
-  }
-});
+exports.exchange.authorizationCode = require('./exchange/authorizationCode');
+exports.exchange.clientCredentials = require('./exchange/clientCredentials');
+exports.exchange.password = require('./exchange/password');
+exports.exchange.refreshToken = require('./exchange/refreshToken');
+
 
 // alias exchanges
 exports.exchange.code = exports.exchange.authorizationCode;


### PR DESCRIPTION
direct require instead of fs.readDir allows oauth2orize to be packaged with webpack 