### PR TITLE
update out-of-date dev-dependency according to npm audit security report

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,11 +45,11 @@
     "debug": "2.x.x"
   },
   "devDependencies": {
-    "make-node": "0.3.x",
-    "mocha": "2.x.x",
     "chai": "2.x.x",
     "chai-connect-middleware": "0.3.x",
-    "chai-oauth2orize-grant": "0.3.x"
+    "chai-oauth2orize-grant": "0.3.x",
+    "make-node": "0.3.x",
+    "mocha": "8.x.x"
   },
   "engines": {
     "node": ">= 0.4.0"


### PR DESCRIPTION
### Update outdated `mocha` dev-dependency to fix npm security audit warnings
This PR fixes the open issue #240 

### Checklist

- [X] I have read the [CONTRIBUTING](https://github.com/jaredhanson/oauth2orize/blob/master/CONTRIBUTING.md) guidelines.
- [ ] I have added test cases which verify the correct operation of this feature or patch.
- [ ] I have added documentation pertaining to this feature or patch.
- [X] The automated test suite (`$ make test`) executes successfully.
- [ ] The automated code linting (`$ make lint`) executes successfully.
